### PR TITLE
Changes to allow DSC bootstrapping

### DIFF
--- a/Chocolatey/DscResources/ChocolateyFeature/ChocolateyFeature.psm1
+++ b/Chocolatey/DscResources/ChocolateyFeature/ChocolateyFeature.psm1
@@ -77,8 +77,8 @@ function Test-TargetResource
     Import-Module $PSScriptRoot\..\..\Chocolatey.psd1 -verbose:$False
 
     $EnsureResultMap = @{
-        'Present'=$true
-        'Absent'=$false
+        'Present'=$false
+        'Absent'=$true
     }
     
     return (Test-ChocolateyFeature -Name $Name -Disabled:($EnsureResultMap[$Ensure]))

--- a/Chocolatey/DscResources/ChocolateyPackage/ChocolateyPackage.psm1
+++ b/Chocolatey/DscResources/ChocolateyPackage/ChocolateyPackage.psm1
@@ -83,10 +83,7 @@ function Set-TargetResource
 
     Process {
         Import-Module $PSScriptRoot\..\..\Chocolatey.psd1 -verbose:$False
-        Write-Verbose "Building Command with parameters:"
         
-        $TestResult = Test-ChocolateyPackageIsInstalled @TestParams
-
         $ChocoCommand = switch ($Ensure) {
             'Present' {
                 if($testResult.VersionGreaterOrEqual) {

--- a/Chocolatey/DscResources/ChocolateyPackage/ChocolateyPackage.psm1
+++ b/Chocolatey/DscResources/ChocolateyPackage/ChocolateyPackage.psm1
@@ -84,13 +84,23 @@ function Set-TargetResource
     Process {
         Import-Module $PSScriptRoot\..\..\Chocolatey.psd1 -verbose:$False
         
+        $TestParams = @{
+            Name = $Name
+        }
+        if($Version) { $TestParams.Add('Version',$Version) }
+
+        $testResult = Test-ChocolateyPackageIsInstalled @TestParams
         $ChocoCommand = switch ($Ensure) {
             'Present' {
                 if($testResult.VersionGreaterOrEqual) {
                     Get-Command Update-ChocolateyPackage 
                 }
-                else {
+                elseif(!$UpdateOnly) {
                     Get-Command Install-ChocolateyPackage 
+                }
+                else {
+                    Write-Verbose "Nothing to do: UpdateOnly : $UpdateOnly"
+                    return
                 }
                  
             }

--- a/Chocolatey/public/Get-ChocolateyFeature.ps1
+++ b/Chocolatey/public/Get-ChocolateyFeature.ps1
@@ -35,7 +35,7 @@ function Get-ChocolateyFeature {
         }
 
         #Run once to update config file
-		& $chocoCmd.Source features
+		& $chocoCmd.Source features | Out-Null
 
         $ChocoConfigPath = join-path $chocoCmd.Path ..\..\config\chocolatey.config -Resolve
         $ChocoXml = [xml]::new()

--- a/Chocolatey/public/Get-ChocolateyFeature.ps1
+++ b/Chocolatey/public/Get-ChocolateyFeature.ps1
@@ -33,6 +33,10 @@ function Get-ChocolateyFeature {
         if (-not ($chocoCmd = Get-Command 'choco.exe' -CommandType Application -ErrorAction SilentlyContinue)) {
             Throw "Chocolatey Software not found"
         }
+
+        #Run once to update config file
+		& $chocoCmd.Source features
+
         $ChocoConfigPath = join-path $chocoCmd.Path ..\..\config\chocolatey.config -Resolve
         $ChocoXml = [xml]::new()
         $ChocoXml.Load($ChocoConfigPath)

--- a/Chocolatey/public/Get-ChocolateyFeature.ps1
+++ b/Chocolatey/public/Get-ChocolateyFeature.ps1
@@ -35,7 +35,7 @@ function Get-ChocolateyFeature {
         }
 
         #Run once to update config file
-		& $chocoCmd.Source features | Out-Null
+		$null = & $chocoCmd features
 
         $ChocoConfigPath = join-path $chocoCmd.Path ..\..\config\chocolatey.config -Resolve
         $ChocoXml = [xml]::new()

--- a/Chocolatey/public/Install-ChocolateySoftware.ps1
+++ b/Chocolatey/public/Install-ChocolateySoftware.ps1
@@ -240,4 +240,6 @@ function Install-ChocolateySoftware {
         $null = [System.IO.Directory]::CreateDirectory($chocoPkgDir)
     }
     Copy-Item "$file" "$nupkg" -Force -ErrorAction SilentlyContinue
+
+    & "$chocoPath\choco.exe" -v
 }

--- a/Chocolatey/public/Install-ChocolateySoftware.ps1
+++ b/Chocolatey/public/Install-ChocolateySoftware.ps1
@@ -241,5 +241,7 @@ function Install-ChocolateySoftware {
     }
     Copy-Item "$file" "$nupkg" -Force -ErrorAction SilentlyContinue
 
-    & "$chocoPath\choco.exe" -v
+    if ($ChocoVersion = & "$chocoPath\choco.exe" -v) {
+        Write-Verbose "Installed Chocolatey Version: $ChocoVersion"
+    }
 }


### PR DESCRIPTION
While trying to use the module to configure Chocolatey on a new machine, ran into a couple of issues that tripped me up when trying to set a bunch of settings in a single DSC configurations.

## Choco install method
When using Install-ChocolateySoftware, the pull from Nuget and install script worked but it didn't create itself a config file. This is bothersome for two reasons, you need admin to write to C:\ProgramData and it then breaks the rest of the steps. Calling chocolatey as an admin user allowed to run the script creates this directory.

## Install package throws error
When installing a package using the ChocolateyPackage resource, I was seeing an error being thrown despite the install completing. I think it's [this](https://github.com/gaelcolas/Chocolatey/commit/0d4140303283b989332892168757cb4799c1e4d1#diff-28ca0165e5591d0864c6d7945573ea36L88) line that's breaking it because we never set TestParams. Not sure if you want to test before install, but that result variable is never used either so I assumed this was erroneous

## Feature resource test reversed
Must have been some confusion about the -Disabled flag on this cmdlet as the Ensure/Present values were reversed, so the test was returning false results. Switched and now behaves as expected 

## Choco features not updated
When installing the Chocolatey licensed extension, the available features are updated - however this is not reflected in the config XML until after the executable is run again. I've added a call to the exe before we parse the XML, which adds some overhead. Given that the available features can be affected outside of the module I thought it would be sensible to keep it.