### PR TITLE
fixing support for --params

### DIFF
--- a/Chocolatey/private/Get-ChocolateyDefaultArgument.ps1
+++ b/Chocolatey/private/Get-ChocolateyDefaultArgument.ps1
@@ -50,10 +50,11 @@ Arguments to pass to the Installer (Not Package args)
 .PARAMETER InstallArgumentsSensitive
 Arguments to pass to the Installer that should be obfuscated from log and output.
 
-.PARAMETER PackageArguments
-Arguments to pass to the Package
+.PARAMETER PackageParameters
+PackageParameters - Parameters to pass to the package, that should be handled by the ChocolateyInstall.ps1
 
-.PARAMETER PackageArgumentsSensitive
+
+.PARAMETER PackageParametersSensitive
 Arguments to pass to the Package that should be obfuscated from log and output.
 
 .PARAMETER OverrideArguments
@@ -332,7 +333,13 @@ function Get-ChocolateyDefaultArgument {
             ValueFromPipelineByPropertyName
         )]
         [String]
-        $PackageArgumentsSensitive,
+        $PackageParameters,
+
+        [Parameter(
+            ValueFromPipelineByPropertyName
+        )]
+        [String]
+        $PackageParametersSensitive,
 
         [Parameter(
             ValueFromPipelineByPropertyName
@@ -634,7 +641,6 @@ function Get-ChocolateyDefaultArgument {
 
             #Install Parameters
             'x86'               { "--x86"}
-            'InstallArguments'  { "--install-arguments=`"$InstallArguments`""}
             'OverrideArguments' { '--override-arguments' }
             'NotSilent'         { '--not-silent' }
             'ApplyArgsToDependencies' { '--apply-install-arguments-to-dependencies' }
@@ -659,9 +665,10 @@ function Get-ChocolateyDefaultArgument {
             'SkipVirusCheck'    { '--skip-virus-check' }
             'VirusCheck'        { '--virus-check' }
             'VirusPositive'     { "--virus-positives-minimum=`"$VirusPositive`"" }
+            'InstallArguments'  { "--install-arguments=`"$InstallArguments`""}
             'InstallArgumentsSensitive' { "--install-arguments-sensitive=`"$InstallArgumentsSensitive`""}
-            'PackageArgumentsSensitive' { "--package-arguments-sensitive=`"$PackageArgumentsSensitive`""}
-            'PackageArguments' { "--package-arguments=`"$PackageArguments`""}
+            'PackageParameters' {"--package-parameters=`"$PackageParameters`"" }
+            'PackageParametersSensitive' { "--package-parameters-sensitive=`"$PackageParametersSensitive`""}
             'MaxDownloadRate'   { "--maximum-download-bits-per-second=$MaxDownloadRate" }
             'IgnoreRememberedArguments' { '--ignore-remembered-arguments' }
             'UseRememberedArguments' { '--use-remembered-options' }

--- a/Chocolatey/public/Install-ChocolateyPackage.ps1
+++ b/Chocolatey/public/Install-ChocolateyPackage.ps1
@@ -54,7 +54,10 @@ InstallArgumentsSensitive - Install Arguments to pass to the native
 installer in the package that are sensitive and you do not want logged. 
 Defaults to unspecified. Available in 0.10.1+. [Licensed editions](https://chocolatey.org/compare) only.
 
-.PARAMETER PackageArgumentsSensitive
+.PARAMETER PackageParameters
+PackageParameters - Parameters to pass to the package, that should be handled by the ChocolateyInstall.ps1
+
+.PARAMETER PackageParametersSensitive
 PackageParametersSensitive - Package Parameters to pass the package that 
 are sensitive and you do not want logged. Defaults to unspecified. 
 Available in 0.10.1+. [Licensed editions](https://chocolatey.org/compare) only.
@@ -232,12 +235,18 @@ function Install-ChocolateyPackage {
         )]
         [String]
         $InstallArgumentsSensitive,
+        
+        [Parameter(
+            ValueFromPipelineByPropertyName
+        )]
+        [String]
+        $PackageParameters,
 
         [Parameter(
             ValueFromPipelineByPropertyName
         )]
         [String]
-        $PackageArgumentsSensitive,
+        $PackageParametersSensitive,
 
         [Parameter(
             ValueFromPipelineByPropertyName

--- a/Chocolatey/public/Update-ChocolateyPackage.ps1
+++ b/Chocolatey/public/Update-ChocolateyPackage.ps1
@@ -54,7 +54,10 @@ InstallArgumentsSensitive - Install Arguments to pass to the native
 installer in the package that are sensitive and you do not want logged. 
 Defaults to unspecified. Available in 0.10.1+. [Licensed editions](https://chocolatey.org/compare) only.
 
-.PARAMETER PackageArgumentsSensitive
+.PARAMETER PackageParameters
+PackageParameters - Parameters to pass to the package, that should be handled by the ChocolateyInstall.ps1
+
+.PARAMETER PackageParametersSensitive
 PackageParametersSensitive - Package Parameters to pass the package that 
 are sensitive and you do not want logged. Defaults to unspecified. 
 Available in 0.10.1+. [Licensed editions](https://chocolatey.org/compare) only.
@@ -217,12 +220,18 @@ function Update-ChocolateyPackage {
         )]
         [String]
         $InstallArgumentsSensitive,
+        
+        [Parameter(
+            ValueFromPipelineByPropertyName
+        )]
+        [String]
+        $PackageParameters,
 
         [Parameter(
             ValueFromPipelineByPropertyName
         )]
         [String]
-        $PackageArgumentsSensitive,
+        $PackageParametersSensitive,
 
         [Parameter(
             ValueFromPipelineByPropertyName


### PR DESCRIPTION
there was a typo in the code using PackageArguments instead of PackageParameters.

Fixed, and that should allow the DSC resource to work with args as well.