### PR TITLE
fix Get-TargetResource for ChocolateyFeature

### DIFF
--- a/Chocolatey/DscResources/ChocolateyFeature/ChocolateyFeature.psm1
+++ b/Chocolatey/DscResources/ChocolateyFeature/ChocolateyFeature.psm1
@@ -25,7 +25,7 @@ function Get-TargetResource
     $FeatureConfig = Get-ChocolateyFeature -Name $Name
 
     return @{
-        Ensure = @('Absent','Present')[[int]$FeatureConfig.enabled]
+        Ensure = @('Absent','Present')[[int][bool]$FeatureConfig.enabled]
         Name = $FeatureConfig.Name
     }
 }


### PR DESCRIPTION
The Get-ChocolateyFeature command parses an XML files to give the values back, but they come as strings rather than typed variables. We should be able to trust the XML to contain a valid true/false, so cast it to bool first and this line works.

The rest of the commands that manage the features seem to work ok, so this should be the only change needed for the feature resource.