### PR TITLE
!Deploy & release Fix#30

### DIFF
--- a/Chocolatey/public/Get-ChocolateyPackage.ps1
+++ b/Chocolatey/public/Get-ChocolateyPackage.ps1
@@ -136,7 +136,6 @@ function Get-ChocolateyPackage {
         )]
         [String]
         $CacheLocation
-
     )
 
     Process {
@@ -161,7 +160,6 @@ function Get-ChocolateyPackage {
             $ChocoArguments = [System.Collections.ArrayList]$ChocoArguments
             $ChocoArguments.remove('--verbose')
         }
-
 
         if ( $LocalOnly -and
             !$PSboundparameters.containsKey('Version') -and


### PR DESCRIPTION
The problem in #30 was when only 1 package was returned (i.e. only Chocolatey is installed on the system).
The `$UnfilteredResult` would be a PSObject, and not a collection. Replacing with `| Where-Object` did the trick.

Took the opportunity to change the logic of the cache, to something that's a bit more clear and that makes sense now... :)