### PR TITLE
Parse any bool values passed as choco options

### DIFF
--- a/Chocolatey/DscResources/ChocolateyPackage/ChocolateyPackage.psm1
+++ b/Chocolatey/DscResources/ChocolateyPackage/ChocolateyPackage.psm1
@@ -125,7 +125,14 @@ function Set-TargetResource
             )
             {
                 Write-Verbose "`t -$ChocoOptionName $($ChocoOptions[$ChocoOptionName])"
-                $ChocoCommandParams.Add($ChocoOptionName,$ChocoOptions[$ChocoOptionName])
+                $ChocoCommandParams.Add($ChocoOptionName,$(
+                        if ($ChocoOptions[$ChocoOptionName] -in @('True','False') {
+                            [bool]::Parse($ChocoOptions[$ChocoOptionName])
+                        }
+                        else {
+                            $ChocoOptions[$ChocoOptionName]
+                        }
+                    ))
             }
         }
         Write-Verbose "Starting the Execution..."


### PR DESCRIPTION
 When passed in from a MOF the bool will actually be a string and parameter binding doesn't work for those, especially for switches. So we need to parse them to make sure they get splatted correctly.

This was the simplest fix I could implement that didn't involve looping through the hashtable and creating a new one with each value parsed if needed.