### PR TITLE
fixing functions not using repair for Env Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where Test-ChocolateyInstall and Get-ChocolateyCommand would not
+  refresh the process environment Path variable correctly.
+
 ## [0.10.1] - 2025-10-23
 
 ### Created

--- a/source/public/software/Get-ChocolateyCommand.ps1
+++ b/source/public/software/Get-ChocolateyCommand.ps1
@@ -52,8 +52,7 @@ function Get-ChocolateyCommand
         {
             Write-Debug -Message 'Loading machine Path Environment variable into session.'
             # This is to reload Path written to registry but not yet loaded into the process.
-            $envPath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
-            [Environment]::SetEnvironmentVariable($envPath, 'Process')
+            Repair-ProcessEnvPath
 
             # Lookup for the choco.exe command in Path
             Write-Debug -Message ('Looking up chocolatey from Path.')

--- a/source/public/software/Test-ChocolateyInstall.ps1
+++ b/source/public/software/Test-ChocolateyInstall.ps1
@@ -31,8 +31,7 @@ function Test-ChocolateyInstall
 
     Write-Verbose -Message 'Loading machine Path Environment variable into session.'
     # This is to reload Path written to registry but not yet loaded into the process.
-    $envPath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
-    [Environment]::SetEnvironmentVariable($envPath, 'Process')
+    Repair-ProcessEnvPath
 
     if (-not [string]::IsNullOrEmpty($InstallDir))
     {


### PR DESCRIPTION
The Env Path was overriden by Machine path when running a command because Get-ChocolateyCommand and Test-ChocolateyInstall were not using the newly created repair function.