### PR TITLE
fixing command overriding the $Env:Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue where Test-ChocolateyInstall and Get-ChocolateyCommand would not
   refresh the process environment Path variable correctly.
 
+- Fixed issue where Get-ChocolateyInstallPath was updating the path incorrectly.
+
 ## [0.10.1] - 2025-10-23
 
 ### Created

--- a/source/private/Get-ChocolateyInstallPath.ps1
+++ b/source/private/Get-ChocolateyInstallPath.ps1
@@ -23,7 +23,7 @@ function Get-ChocolateyInstallPath
     )
 
     # Update path from registry if not set in process
-    $Env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+    Repair-ProcessEnvPath
 
     # Get ChocolateyInstall path from HKLM
     $chocolateyInstall = [System.Environment]::GetEnvironmentVariable('ChocolateyInstall', 'Machine')


### PR DESCRIPTION
Fixed issue where Get-ChocolateyInstallPath was updating the path incorrectly.