### PR TITLE
Add Save-ChocolateyPackage command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   license file from a source path or XML content.
 - Added `Remove-ChocolateyLicense` to remove the Chocolatey license file and
   revert to unlicensed Chocolatey behavior.
+- Added `Save-ChocolateyPackage` to wrap `choco download`, including licensed
+  download, virus-scan, and internalization switches.
 - Aligned wiki generation with the explicit Sampler docs workflow so content
   from `source\WikiSource` is prepared and published to the GitHub wiki.
 - Added a `Home.md` wiki landing page under `source\WikiSource`.
@@ -43,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `Get-ChocolateyInstallPath` to honor a valid non-standard
   `ChocolateyInstall` path before falling back to the default install location.
+- `Save-ChocolateyPackage` now throws when licensed-only download parameters are
+  used without an installed Chocolatey license file.
 - Fixing issue #105 where Uninstall-ChocolateySoftware fails.
 - Making version parameter of `Update-ChocolateyPackage` not mandatory.
 - Fixing issue #107 to allow for username field to be set on ChocolateySource

--- a/source/WikiSource/Home.md
+++ b/source/WikiSource/Home.md
@@ -23,6 +23,7 @@ Generated command pages in the published wiki include:
 - `Install-ChocolateySoftware`
 - `Install-ChocolateyLicense`
 - `Remove-ChocolateyLicense`
+- `Save-ChocolateyPackage`
 - `Install-ChocolateyPackage`
 - `Update-ChocolateyPackage`
 - `Uninstall-ChocolateyPackage`

--- a/source/WikiSource/LicensedChocolatey.md
+++ b/source/WikiSource/LicensedChocolatey.md
@@ -4,6 +4,7 @@ This module now includes public commands to install and remove a Chocolatey lice
 
 - `Install-ChocolateyLicense`
 - `Remove-ChocolateyLicense`
+- `Save-ChocolateyPackage`
 
 ## Installing a license
 
@@ -59,6 +60,19 @@ You should still install the licensed extension promptly after installing the li
 ```powershell
 Install-ChocolateyPackage -Name 'chocolatey.extension'
 ```
+
+## Downloading or internalizing packages
+
+With the licensed extension installed, you can save packages locally and use
+internalization features through:
+
+```powershell
+Save-ChocolateyPackage -Name 'notepadplusplus.install' -Internalize
+```
+
+If you use licensed-only `Save-ChocolateyPackage` parameters such as
+`-Internalize`, `-UseDownloadCache`, or `-SkipVirusCheck` without first
+installing a Chocolatey license, the command throws before invoking Chocolatey.
 
 ## Recommended sequence
 

--- a/source/private/Get-ChocolateyDefaultArgument.ps1
+++ b/source/private/Get-ChocolateyDefaultArgument.ps1
@@ -47,11 +47,23 @@ Credential to authenticate to the source feed.
 .PARAMETER ProxyCredential
 Credential for the Proxy.
 
+.PARAMETER ProxyLocation
+Explicit proxy location for Chocolatey commands.
+
+.PARAMETER ProxyBypassList
+Regular-expression list of locations that should bypass the proxy.
+
+.PARAMETER ProxyBypassOnLocal
+Bypass the proxy for local connections.
+
 .PARAMETER Force
 Force the action being targeted.
 
 .PARAMETER CacheLocation
 Location where the download will be cached.
+
+.PARAMETER OutputDirectory
+Directory where downloaded package files should be saved.
 
 .PARAMETER InstallArguments
 Arguments to pass to the Installer (Not Package args)
@@ -99,6 +111,12 @@ Should install arguments be used exclusively without appending to current packag
     switch is not recommended if using sources that download resources from
     the internet. Overrides the default feature 'allowEmptyChecksums' set to
     'False'. Available in 0.10.0+.
+
+.PARAMETER AllowEmptyChecksumSecure
+    Allow empty checksums for downloaded resources from secure locations (HTTPS).
+
+.PARAMETER RequireChecksum
+    Require checksums for downloaded resources.
 
 .PARAMETER ignorePackageCodes
     IgnorePackageExitCodes - Exit with a 0 for success and 1 for non-success,
@@ -148,6 +166,9 @@ Should install arguments be used exclusively without appending to current packag
     is VirusTotal. Overrides the default configuration value
     'virusCheckMinimumPositives' set to '5'. Available in 0.9.10+. Licensed
     editions only. See https://chocolatey.org/docs/features-virus-check
+
+.PARAMETER MaxDownloadRate
+Maximum download rate in bits per second.
 
 .PARAMETER OrderByPopularity
     Order the community packages (chocolatey.org) by popularity.
@@ -236,6 +257,51 @@ Should install arguments be used exclusively without appending to current packag
 
 .PARAMETER IncludeConfiguredSources
     IncludeConfiguredSources - When searching, include all sources from
+
+.PARAMETER InstalledPackages
+    Download all installed Chocolatey packages.
+
+.PARAMETER IgnoreUnfound
+    Continue downloading remaining packages when one package cannot be found.
+
+.PARAMETER DisablePackageRepositoryOptimizations
+    Disable Chocolatey's package repository query optimizations.
+
+.PARAMETER IgnoreDependenciesFromSource
+    Ignore dependencies that are already present on the named configured source.
+
+.PARAMETER Internalize
+    Internalize a package by downloading remote resources and recompiling it.
+
+.PARAMETER ResourcesLocation
+    Resources location to use when internalizing a package.
+
+.PARAMETER DownloadLocation
+    Local download location to use when internalizing resources.
+
+.PARAMETER InternalizeAllUrls
+    Internalize all discovered URLs during package internalization.
+
+.PARAMETER AppendUseOriginalLocation
+    Append `-UseOriginalLocation` to internalized helper calls.
+
+.PARAMETER ForceSelfService
+    Force handling through Chocolatey self-service when available.
+
+.PARAMETER AllowUnofficialBuild
+    Allow Chocolatey to run when using an unofficial build.
+
+.PARAMETER FailOnStandardError
+    Fail if the command writes to the standard error stream.
+
+.PARAMETER UseSystemPowerShell
+    Run PowerShell in an external process instead of the embedded host.
+
+.PARAMETER SkipCompatibilityChecks
+    Skip Chocolatey and licensed extension compatibility warnings.
+
+.PARAMETER IgnoreHttpCache
+    Ignore cached HTTP responses when querying sources.
 
 .PARAMETER WhatIf
     Simulates the command that would be run by adding.
@@ -547,12 +613,28 @@ function Get-ChocolateyDefaultArgument
         $ProxyCredential,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ProxyLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string[]]
+        $ProxyBypassList,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ProxyBypassOnLocal,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
         [Switch]
         $Force,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [System.String]
         $CacheLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $OutputDirectory,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [String]
@@ -608,6 +690,14 @@ function Get-ChocolateyDefaultArgument
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [Switch]
+        $AllowEmptyChecksumSecure,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Switch]
+        $RequireChecksum,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Switch]
         $ignorePackageCodes,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
@@ -639,6 +729,11 @@ function Get-ChocolateyDefaultArgument
         [ValidateNotNullOrEmpty()]
         [int]
         $VirusPositive,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [int]
+        $MaxDownloadRate,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
@@ -734,6 +829,66 @@ function Get-ChocolateyDefaultArgument
         [Parameter()]
         [switch]
         $IncludeConfiguredSources,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $InstalledPackages,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreUnfound,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $DisablePackageRepositoryOptimizations,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $IgnoreDependenciesFromSource,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Internalize,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ResourcesLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $DownloadLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $InternalizeAllUrls,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AppendUseOriginalLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ForceSelfService,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AllowUnofficialBuild,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $FailOnStandardError,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $UseSystemPowerShell,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $SkipCompatibilityChecks,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreHttpCache,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [Switch]
@@ -843,13 +998,25 @@ function Get-ChocolateyDefaultArgument
             {
                 "--allow-unofficial-build"
             }
+            'AllowUnofficialBuild'
+            {
+                "--allow-unofficial-build"
+            }
             'FailOnSTDErr'
+            {
+                '--fail-on-stderr'
+            }
+            'FailOnStandardError'
             {
                 '--fail-on-stderr'
             }
             'Proxy'
             {
-                "--Proxy=`"$Proxy`""
+                "--proxy=`"$Proxy`""
+            }
+            'ProxyLocation'
+            {
+                "--proxy=`"$ProxyLocation`""
             }
             'ProxyCredential'
             {
@@ -869,6 +1036,22 @@ function Get-ChocolateyDefaultArgument
             'ProxyBypassLocal'
             {
                 "--proxy-bypass-on-local"
+            }
+            'ProxyBypassOnLocal'
+            {
+                "--proxy-bypass-on-local"
+            }
+            'UseSystemPowerShell'
+            {
+                '--use-system-powershell'
+            }
+            'SkipCompatibilityChecks'
+            {
+                '--skip-compatibility-checks'
+            }
+            'IgnoreHttpCache'
+            {
+                '--ignore-http-cache'
             }
 
             #List / Search Parameters
@@ -919,6 +1102,10 @@ function Get-ChocolateyDefaultArgument
             'Version'
             {
                 "--version=`"$version`""
+            }
+            'OutputDirectory'
+            {
+                "--output-directory=`"$OutputDirectory`""
             }
             'exact'
             {
@@ -974,6 +1161,46 @@ function Get-ChocolateyDefaultArgument
             'RequireChecksum'
             {
                 '--requirechecksum'
+            }
+            'InstalledPackages'
+            {
+                '--installed-packages'
+            }
+            'IgnoreUnfound'
+            {
+                '--ignore-unfound-packages'
+            }
+            'DisablePackageRepositoryOptimizations'
+            {
+                '--disable-package-repository-optimizations'
+            }
+            'IgnoreDependenciesFromSource'
+            {
+                "--ignore-dependencies-from-source=`"$IgnoreDependenciesFromSource`""
+            }
+            'Internalize'
+            {
+                '--internalize'
+            }
+            'ResourcesLocation'
+            {
+                "--resources-location=`"$ResourcesLocation`""
+            }
+            'DownloadLocation'
+            {
+                "--download-location=`"$DownloadLocation`""
+            }
+            'InternalizeAllUrls'
+            {
+                '--internalize-all-urls'
+            }
+            'AppendUseOriginalLocation'
+            {
+                '--append-use-original-location'
+            }
+            'ForceSelfService'
+            {
+                '--force-self-service'
             }
             'Checksum'
             {

--- a/source/private/Test-ChocolateyLicenseInstalled.ps1
+++ b/source/private/Test-ChocolateyLicenseInstalled.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+    Tests whether a Chocolatey license file is installed.
+
+.DESCRIPTION
+    Returns `$true` when the standard Chocolatey license file exists under the
+    resolved Chocolatey installation directory; otherwise returns `$false`.
+
+.PARAMETER InstallDir
+    Path where Chocolatey is installed. Defaults to the resolved
+    ChocolateyInstall path.
+
+.EXAMPLE
+    Test-ChocolateyLicenseInstalled
+
+    Returns whether a Chocolatey license file is currently installed.
+#>
+function Test-ChocolateyLicenseInstalled
+{
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param
+    (
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $InstallDir = (Get-ChocolateyInstallPath -ErrorAction 'Stop')
+    )
+
+    $licensePath = Join-Path -Path $InstallDir -ChildPath 'license\chocolatey.license.xml'
+    return (Test-Path -Path $licensePath -PathType 'Leaf')
+}

--- a/source/public/package/Save-ChocolateyPackage.ps1
+++ b/source/public/package/Save-ChocolateyPackage.ps1
@@ -1,0 +1,408 @@
+<#
+.SYNOPSIS
+    Saves Chocolatey packages locally and can internalize them when licensed features are available.
+
+.DESCRIPTION
+    Wraps `choco download` to download one or more packages to a local directory.
+    When the Chocolatey Licensed Extension is installed, this command can also use
+    licensed download features such as private CDN download cache, virus scan
+    switches, and package internalization. Licensed-only parameters throw when
+    no Chocolatey license file is installed.
+
+.PARAMETER Name
+    Package name to save from the configured source or a specified source.
+
+.PARAMETER InstalledPackages
+    Save all currently installed Chocolatey packages instead of specifying package names.
+
+.PARAMETER Version
+    Specific version to download. Defaults to the latest available version.
+
+.PARAMETER Source
+    Source to find the package(s) to download. Defaults to configured sources.
+
+.PARAMETER Credential
+    Credential used with authenticated feeds.
+
+.PARAMETER Prerelease
+    Include prerelease packages when resolving a package to download.
+
+.PARAMETER OutputDirectory
+    Directory where downloaded package files should be saved. Defaults to the current directory.
+
+.PARAMETER Force
+    Force the download behavior when Chocolatey supports it.
+
+.PARAMETER CacheLocation
+    Location for Chocolatey's download cache.
+
+.PARAMETER NoProgress
+    Do not show download progress percentages.
+
+.PARAMETER AcceptLicense
+    Accept license dialogs automatically. Reserved for future use.
+
+.PARAMETER Timeout
+    Command execution timeout in seconds. Use `0` for infinite timeout.
+
+.PARAMETER ProxyLocation
+    Explicit proxy location to use for the Chocolatey command.
+
+.PARAMETER ProxyCredential
+    Credential to authenticate to the proxy.
+
+.PARAMETER ProxyBypassList
+    Regular-expression list of hosts that should bypass the proxy.
+
+.PARAMETER ProxyBypassOnLocal
+    Bypass the proxy for local connections.
+
+.PARAMETER AllowUnofficialBuild
+    Allow the command to run when using an unofficial Chocolatey build.
+
+.PARAMETER FailOnStandardError
+    Fail if Chocolatey writes to the standard error stream.
+
+.PARAMETER UseSystemPowerShell
+    Run PowerShell in an external process instead of the embedded host.
+
+.PARAMETER SkipCompatibilityChecks
+    Skip Chocolatey and licensed extension compatibility warnings.
+
+.PARAMETER IgnoreHttpCache
+    Ignore cached HTTP responses when querying sources.
+
+.PARAMETER IgnoreDependencies
+    Ignore package dependencies while downloading packages.
+
+.PARAMETER IgnoreUnfound
+    Continue downloading remaining packages when one package cannot be found.
+
+.PARAMETER DisablePackageRepositoryOptimizations
+    Disable Chocolatey's package repository query optimizations.
+
+.PARAMETER IgnoreChecksum
+    Ignore checksums provided by the package.
+
+.PARAMETER AllowEmptyChecksum
+    Allow empty or missing checksums for downloaded resources from non-secure locations.
+
+.PARAMETER AllowEmptyChecksumSecure
+    Allow empty checksums for downloaded resources from secure locations.
+
+.PARAMETER RequireChecksum
+    Require packages to provide checksums for downloaded resources.
+
+.PARAMETER IgnoreDependenciesFromSource
+    Ignore dependencies that are already present on the named configured source.
+
+.PARAMETER Internalize
+    Internalize the package by downloading external resources and recompiling it.
+
+.PARAMETER ResourcesLocation
+    Resources location to use during internalization.
+
+.PARAMETER DownloadLocation
+    Local download location to use during internalization.
+
+.PARAMETER InternalizeAllUrls
+    Internalize all discovered URLs, not only known helper-based downloads.
+
+.PARAMETER AppendUseOriginalLocation
+    Append `-UseOriginalLocation` to internalized helper calls.
+
+.PARAMETER SkipCache
+    Bypass Chocolatey's private CDN download cache.
+
+.PARAMETER UseDownloadCache
+    Use Chocolatey's private CDN download cache when available.
+
+.PARAMETER SkipVirusCheck
+    Skip the licensed virus check for downloaded files.
+
+.PARAMETER VirusCheck
+    Enable the licensed virus check for downloaded files.
+
+.PARAMETER VirusPositive
+    Minimum number of positive virus scan results required to flag a package.
+
+.PARAMETER ForceSelfService
+    Force handling through Chocolatey self-service when available.
+
+.EXAMPLE
+    Save-ChocolateyPackage -Name 'sysinternals' -OutputDirectory 'C:\packages'
+
+    Downloads the latest sysinternals package into `C:\packages`.
+
+.EXAMPLE
+    Save-ChocolateyPackage -Name 'notepadplusplus.install' -Internalize -ResourcesLocation '\\server\packages'
+
+    Downloads and internalizes the package using licensed Chocolatey features.
+
+.NOTES
+    https://docs.chocolatey.org/en-us/choco/commands/download/
+#>
+function Save-ChocolateyPackage
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '')]
+    [CmdletBinding(DefaultParameterSetName = 'ByName', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.String[]]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'InstalledPackages')]
+        [switch]
+        $InstalledPackages,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Version,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        $Source,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [PSCredential]
+        $Credential,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Prerelease,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $OutputDirectory,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Force,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $CacheLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $NoProgress,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AcceptLicense,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [int]
+        $Timeout,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ProxyLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [PSCredential]
+        $ProxyCredential,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string[]]
+        $ProxyBypassList,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ProxyBypassOnLocal,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AllowUnofficialBuild,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $FailOnStandardError,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $UseSystemPowerShell,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $SkipCompatibilityChecks,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreHttpCache,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreDependencies,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreUnfound,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $DisablePackageRepositoryOptimizations,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreChecksum,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AllowEmptyChecksum,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AllowEmptyChecksumSecure,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $RequireChecksum,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $IgnoreDependenciesFromSource,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Internalize,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ResourcesLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $DownloadLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $InternalizeAllUrls,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AppendUseOriginalLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $SkipCache,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $UseDownloadCache,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $SkipVirusCheck,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $VirusCheck,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [int]
+        $VirusPositive,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ForceSelfService
+    )
+
+    begin
+    {
+        # Validate choco is installed or die. Will load the exe path from module cache.
+        # Should you want to specify an installation directory,
+        # you have to call Get-ChocolateyCommand -InstallDir <path> -Force to set the cache.
+        $chocoCmd = Get-ChocolateyCommand
+    }
+
+    process
+    {
+        $licensedParameterNames = @(
+            'InstalledPackages',
+            'IgnoreDependencies',
+            'IgnoreUnfound',
+            'IgnoreChecksum',
+            'AllowEmptyChecksum',
+            'AllowEmptyChecksumSecure',
+            'RequireChecksum',
+            'IgnoreDependenciesFromSource',
+            'Internalize',
+            'ResourcesLocation',
+            'DownloadLocation',
+            'InternalizeAllUrls',
+            'AppendUseOriginalLocation',
+            'SkipCache',
+            'UseDownloadCache',
+            'SkipVirusCheck',
+            'VirusCheck',
+            'VirusPositive',
+            'ForceSelfService'
+        )
+
+        $requestedLicensedParameters = @(
+            $PSBoundParameters.Keys.Where({ $_ -in $licensedParameterNames })
+        )
+
+        if ($requestedLicensedParameters.Count -gt 0)
+        {
+            $installDir = Get-ChocolateyInstallPath -ErrorAction 'Stop'
+            $licensePath = Join-Path -Path $installDir -ChildPath 'license\chocolatey.license.xml'
+
+            if (-not (Test-ChocolateyLicenseInstalled -InstallDir $installDir))
+            {
+                $parameterList = $requestedLicensedParameters |
+                    Sort-Object |
+                    ForEach-Object { "-$_" }
+
+                throw ("Chocolatey license-specific parameters require an installed license file at '{0}'. Remove the following parameters or install a license first: {1}" -f $licensePath, ($parameterList -join ', '))
+            }
+        }
+
+        $downloadArgumentParameters = @{}
+        foreach ($key in $PSBoundParameters.Keys)
+        {
+            if ($key -ne 'Name')
+            {
+                $downloadArgumentParameters[$key] = $PSBoundParameters[$key]
+            }
+        }
+
+        [System.Collections.Generic.List[string]] $chocoArguments = [System.Collections.Generic.List[string]]::new()
+        $chocoArguments.Add('download')
+
+        if ($PSCmdlet.ParameterSetName -eq 'ByName')
+        {
+            foreach ($packageName in $Name)
+            {
+                $chocoArguments.Add($packageName)
+            }
+        }
+
+        foreach ($argument in (Get-ChocolateyDefaultArgument @downloadArgumentParameters))
+        {
+            $chocoArguments.Add($argument)
+        }
+
+        $target = if ($PSCmdlet.ParameterSetName -eq 'InstalledPackages')
+        {
+            'installed Chocolatey packages'
+        }
+        else
+        {
+            $Name -join ', '
+        }
+
+        if ($PSCmdlet.ShouldProcess($target, 'Save Chocolatey package'))
+        {
+            $chocoArguments.Add('-y')
+            Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
+            &$chocoCmd $chocoArguments | ForEach-Object -Process {
+                Write-Verbose -Message ('{0}' -f $_)
+            }
+        }
+    }
+}

--- a/source/public/package/Save-ChocolateyPackage.ps1
+++ b/source/public/package/Save-ChocolateyPackage.ps1
@@ -400,7 +400,7 @@ function Save-ChocolateyPackage
         {
             $chocoArguments.Add('-y')
             Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
-            &$chocoCmd $chocoArguments | ForEach-Object -Process {
+            &$chocoCmd @chocoArguments | ForEach-Object -Process {
                 Write-Verbose -Message ('{0}' -f $_)
             }
         }

--- a/tests/Unit/Private/Test-ChocolateyLicenseInstalled.tests.ps1
+++ b/tests/Unit/Private/Test-ChocolateyLicenseInstalled.tests.ps1
@@ -1,0 +1,48 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Test-ChocolateyLicenseInstalled {
+    Context 'When the license file exists' {
+        BeforeAll {
+            Mock Test-Path -MockWith { $true }
+        }
+
+        It 'Should return true' {
+            InModuleScope -ScriptBlock {
+                Test-ChocolateyLicenseInstalled -InstallDir 'C:\ProgramData\chocolatey'
+            } | Should -BeTrue
+        }
+    }
+
+    Context 'When the license file does not exist' {
+        BeforeAll {
+            Mock Test-Path -MockWith { $false }
+        }
+
+        It 'Should return false' {
+            InModuleScope -ScriptBlock {
+                Test-ChocolateyLicenseInstalled -InstallDir 'C:\ProgramData\chocolatey'
+            } | Should -BeFalse
+        }
+    }
+}

--- a/tests/Unit/Public/Save-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Save-ChocolateyPackage.tests.ps1
@@ -1,0 +1,123 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Save-ChocolateyPackage {
+    Context 'Default' {
+        BeforeAll {
+            function global:Invoke-FakeChoco {
+                param (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'saved package'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should call Get-ChocolateyCommand' {
+            $null = Save-ChocolateyPackage -Name 'sysinternals'
+            { Assert-MockCalled Get-ChocolateyCommand } | Should -Not -Throw
+        }
+
+        It 'Should not return value' {
+            $return = Save-ChocolateyPackage -Name 'sysinternals'
+
+            $return | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When using licensed-only download parameters' {
+        BeforeAll {
+            function global:Invoke-FakeChoco {
+                param (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'saved package'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+            Mock Get-ChocolateyInstallPath -MockWith { 'C:\ProgramData\chocolatey' }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should throw when no Chocolatey license is installed' {
+            Mock Test-ChocolateyLicenseInstalled -MockWith { $false }
+
+            {
+                Save-ChocolateyPackage -Name 'notepadplusplus.install' -Internalize
+            } | Should -Throw '*license-specific parameters require an installed license file*'
+        }
+
+        It 'Should include licensed download arguments when internalizing a package' {
+            Mock Test-ChocolateyLicenseInstalled -MockWith { $true }
+
+            $null = Save-ChocolateyPackage -Name 'notepadplusplus.install' -Source 'https://community.chocolatey.org/api/v2/' -OutputDirectory 'C:\packages' -Internalize -ResourcesLocation '\\server\share' -DownloadLocation 'C:\staging' -InternalizeAllUrls -AppendUseOriginalLocation -UseDownloadCache -SkipVirusCheck -IgnoreDependenciesFromSource 'InternalRepo'
+
+            $script:capturedArguments | Should -Contain 'download'
+            $script:capturedArguments | Should -Contain 'notepadplusplus.install'
+            $script:capturedArguments | Should -Contain '-s"https://community.chocolatey.org/api/v2/"'
+            $script:capturedArguments | Should -Contain '--output-directory="C:\packages"'
+            $script:capturedArguments | Should -Contain '--internalize'
+            $script:capturedArguments | Should -Contain '--resources-location="\\server\share"'
+            $script:capturedArguments | Should -Contain '--download-location="C:\staging"'
+            $script:capturedArguments | Should -Contain '--internalize-all-urls'
+            $script:capturedArguments | Should -Contain '--append-use-original-location'
+            $script:capturedArguments | Should -Contain '--use-download-cache'
+            $script:capturedArguments | Should -Contain '--skip-virus-check'
+            $script:capturedArguments | Should -Contain '--ignore-dependencies-from-source="InternalRepo"'
+            $script:capturedArguments | Should -Contain '-y'
+        }
+
+        It 'Should support downloading installed packages' {
+            Mock Test-ChocolateyLicenseInstalled -MockWith { $true }
+
+            $null = Save-ChocolateyPackage -InstalledPackages
+
+            $script:capturedArguments | Should -Contain 'download'
+            $script:capturedArguments | Should -Contain '--installed-packages'
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `Test-ChocolateyLicenseInstalled` function to check for the presence of a Chocolatey license file, adds comprehensive parameter support for Chocolatey command wrappers, and documents the new `Save-ChocolateyPackage` command, including licensed-only behaviors. It also includes new unit tests for the license check function and improves documentation for new features and parameters.

**New Functionality:**

* Added `Test-ChocolateyLicenseInstalled` function to determine if a Chocolatey license file is installed, with corresponding unit tests in `Test-ChocolateyLicenseInstalled.tests.ps1`. [[1]](diffhunk://#diff-aa32bc342a48b08ed8d8d3bbedef7677a8451947c2670a5a588c5e14077b2c78R1-R32) [[2]](diffhunk://#diff-0804deb90f09ca0c3bf110f461440b514fa2cf67b474e3dc2f8da9522192973dR1-R48)
* Introduced `Save-ChocolateyPackage` command, which wraps `choco download` and supports licensed features like internalization, virus scanning, and download caching. The command now throws an error if licensed-only parameters are used without a license. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR36-R37) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR48-R49)

**Parameter and Argument Enhancements:**

* Extended `Get-ChocolateyDefaultArgument.ps1` with numerous new parameters (e.g., proxy options, output directory, checksum controls, internalization, and more) to support advanced Chocolatey scenarios and licensed features. All parameters are now documented and mapped to their respective Chocolatey CLI arguments. [[1]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R50-R67) [[2]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R115-R120) [[3]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R170-R172) [[4]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R261-R305) [[5]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R615-R626) [[6]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R635-R638) [[7]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R691-R698) [[8]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R733-R737) [[9]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R833-R892) [[10]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R1001-R1019) [[11]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R1040-R1055) [[12]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R1106-R1109) [[13]](diffhunk://#diff-6b0e936be6e1a91e685e75c6e3c4f4e40068f0df335ef3820eca47e5c5831e12R1165-R1204)

**Documentation Updates:**

* Updated `CHANGELOG.md` and wiki source files to document the new `Save-ChocolateyPackage` command and its licensed-only behaviors, as well as to list it among available commands. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR36-R37) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR48-R49) [[3]](diffhunk://#diff-4ff689846f9c896ab4e3598f4348bcdd256f5966427b380618864283b182ff93R26) [[4]](diffhunk://#diff-26e5301b8ce592922560fd47dab4269fdf5f3f7b4c7360b76ed4079a73d54968R7) [[5]](diffhunk://#diff-26e5301b8ce592922560fd47dab4269fdf5f3f7b4c7360b76ed4079a73d54968R64-R76)

These changes collectively enhance the module's support for licensed Chocolatey features, improve usability through richer parameterization, and ensure that new functionality is well-documented and tested.