### PR TITLE
adding argument completer

### DIFF
--- a/.github/instructions/private-functions.instructions.md
+++ b/.github/instructions/private-functions.instructions.md
@@ -9,6 +9,8 @@ applyTo: 'source/private/**/*.ps1'
 
 - Follow the same comment-based help baseline as public functions, including at least one `.EXAMPLE`.
 - Use `[CmdletBinding()]`.
+- Put `[Parameter()]` on every parameter, even when no explicit metadata is needed.
+- Format each parameter with the attribute, type, and variable name on separate lines, with a blank line between comma-separated parameter declarations.
 - Include `[OutputType(...)]` when output shape is stable and meaningful to document.
 - Use explicit parameter types where the helper contract is stable.
 

--- a/.github/instructions/public-functions.instructions.md
+++ b/.github/instructions/public-functions.instructions.md
@@ -13,6 +13,8 @@ applyTo: 'source/public/**/*.ps1'
   - at least one `.EXAMPLE`
   - `.PARAMETER` help for every parameter.
 - Use `[CmdletBinding()]`.
+- Put `[Parameter()]` on every parameter, even when no explicit metadata is needed.
+- Format each parameter with the attribute, type, and variable name on separate lines, with a blank line between comma-separated parameter declarations.
 - Include `[OutputType(...)]` when the command returns a defined type or stable output shape.
 - Use explicit parameter types where the command contract is stable.
 - Keep parameter names and defaults stable unless intentionally making a breaking change.

--- a/.github/instructions/test-writing.instructions.md
+++ b/.github/instructions/test-writing.instructions.md
@@ -49,6 +49,20 @@ BeforeAll {
 - For commands that mutate system state and use the hidden `RunNonElevated` parameter defaulted from `Assert-ChocolateyIsElevated`, unit tests should normally pass `-RunNonElevated` unless the elevation check itself is the subject of the test.
 - Mock the command-discovery helper that the implementation actually uses. In this repository that is usually `Get-ChocolateyCommand`, not `Get-Command`.
 
+## Windows PowerShell 5.1 compatibility
+
+- Always wrap pipeline expressions in `@()` before calling `.Count` on them. On Windows PowerShell 5.1, a pipeline that produces exactly one object returns a scalar, and scalars without a `Count` property return `$null` instead of `1`. PowerShell 7 adds a synthetic `Count` member to all objects, masking the bug.
+
+  ```powershell
+  # Wrong — returns $null on WinPS 5.1 when exactly one item matches
+  ($collection | Where-Object { ... }).Count | Should -Be 1
+
+  # Correct — @() ensures a true array on both 5.1 and 7
+  @($collection | Where-Object { ... }).Count | Should -Be 1
+  ```
+
+- The same rule applies to any pipeline result where you call `.Count`, `.Length`, or index into the result (`[0]`): wrap in `@()` first.
+
 ## Validation commands
 
 ```powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   revert to unlicensed Chocolatey behavior.
 - Added `Save-ChocolateyPackage` to wrap `choco download`, including licensed
   download, virus-scan, and internalization switches.
+- Added PowerShell argument completer registrations for local Chocolatey package, pin, source,
+  feature, and setting names across the module's wrapper commands.
 - Aligned wiki generation with the explicit Sampler docs workflow so content
   from `source\WikiSource` is prepared and published to the GitHub wiki.
 - Added a `Home.md` wiki landing page under `source\WikiSource`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,29 @@ deployed to [PowerShell Gallery](https://www.powershellgallery.com/).
 Periodically a release version tag will be pushed which will deploy a
 full release to [PowerShell Gallery](https://www.powershellgallery.com/).
 
+## PowerShell argument completers
+
+Importing the module registers PowerShell argument completers for common
+Chocolatey wrapper commands.
+
+- Package name completion for `Get-ChocolateyPackage`,
+  `Uninstall-ChocolateyPackage`, `Update-ChocolateyPackage`, and
+  `Add-ChocolateyPin`
+- Pin name completion for `Get-ChocolateyPin`, `Remove-ChocolateyPin`, and
+  `Test-ChocolateyPin`
+- Source name completion for `Get-ChocolateySource`, `Test-ChocolateySource`,
+  `Enable-ChocolateySource`, `Disable-ChocolateySource`, and
+  `Unregister-ChocolateySource`
+- Feature name completion for `Get-ChocolateyFeature`,
+  `Test-ChocolateyFeature`, `Enable-ChocolateyFeature`, and
+  `Disable-ChocolateyFeature`
+- Setting name completion for `Get-ChocolateySetting`,
+  `Test-ChocolateySetting`, and `Set-ChocolateySetting`
+
+The completers are local-only and do not query remote package feeds. They use
+the current local Chocolatey package, pin, source, feature, and setting data to
+keep tab completion responsive.
+
 ## Contributing
 
 Please check out common DSC Community [contributing guidelines](CONTRIBUTING.md).

--- a/source/WikiSource/ArgumentCompleters.md
+++ b/source/WikiSource/ArgumentCompleters.md
@@ -1,0 +1,36 @@
+# PowerShell argument completers
+
+The Chocolatey module registers PowerShell argument completers when you import
+the module.
+
+## Supported completions
+
+- Package names for `Get-ChocolateyPackage`, `Uninstall-ChocolateyPackage`,
+  `Update-ChocolateyPackage`, and `Add-ChocolateyPin`
+- Pin names for `Get-ChocolateyPin`, `Remove-ChocolateyPin`, and
+  `Test-ChocolateyPin`
+- Source names for `Get-ChocolateySource`, `Test-ChocolateySource`,
+  `Enable-ChocolateySource`, `Disable-ChocolateySource`, and
+  `Unregister-ChocolateySource`
+- Feature names for `Get-ChocolateyFeature`, `Test-ChocolateyFeature`,
+  `Enable-ChocolateyFeature`, and `Disable-ChocolateyFeature`
+- Setting names for `Get-ChocolateySetting`, `Test-ChocolateySetting`, and
+  `Set-ChocolateySetting`
+
+## Behavior
+
+- Completers are registered during module import.
+- Completion is based on local Chocolatey state.
+- Remote package feeds are not queried during completion.
+- Values containing spaces are quoted automatically in the inserted completion
+  text.
+
+## Example
+
+```powershell
+Import-Module Chocolatey
+
+Update-ChocolateyPackage -Name <TAB>
+Set-ChocolateySetting -Name <TAB>
+Disable-ChocolateyFeature -Name <TAB>
+```

--- a/source/WikiSource/Home.md
+++ b/source/WikiSource/Home.md
@@ -10,6 +10,7 @@ The **Chocolatey Module** provides PowerShell commands and DSC resources for ins
 - Manage Chocolatey settings with the `ChocolateySetting` DSC resource.
 - Manage Chocolatey features with the `ChocolateyFeature` DSC resource.
 - Install a Chocolatey license with the `Install-ChocolateyLicense` command.
+- [PowerShell argument completers](ArgumentCompleters.md)
 - [Licensed Chocolatey guidance](LicensedChocolatey.md)
 
 ## Migration

--- a/source/private/New-ChocolateyCompletionResult.ps1
+++ b/source/private/New-ChocolateyCompletionResult.ps1
@@ -1,0 +1,63 @@
+<#
+.SYNOPSIS
+    Creates completion results for Chocolatey argument completers.
+
+.DESCRIPTION
+    Filters candidate values using the current word being completed and returns
+    PowerShell completion results for matching entries.
+
+.PARAMETER Value
+    Candidate values that can be completed.
+
+.PARAMETER WordToComplete
+    Current token text that should be matched against the candidate values.
+
+.EXAMPLE
+    New-ChocolateyCompletionResult -Value @('git', 'googlechrome') -WordToComplete 'g'
+#>
+function New-ChocolateyCompletionResult
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.CompletionResult[]])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [AllowNull()]
+        [string[]]
+        $Value,
+
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]
+        $WordToComplete = ''
+    )
+
+    $candidateValues = $Value |
+        Where-Object -FilterScript { -not [string]::IsNullOrWhiteSpace($_) } |
+        Sort-Object -Unique
+
+    foreach ($item in $candidateValues)
+    {
+        if ($item -notlike "$WordToComplete*")
+        {
+            continue
+        }
+
+        if ($item -match '\s')
+        {
+            $completionText = "'{0}'" -f ($item -replace "'", "''")
+        }
+        else
+        {
+            $completionText = $item
+        }
+
+        [System.Management.Automation.CompletionResult]::new(
+            $completionText,
+            $item,
+            [System.Management.Automation.CompletionResultType]::ParameterValue,
+            $item
+        )
+    }
+}

--- a/source/private/New-ChocolateyCompletionResultForFeatureName.ps1
+++ b/source/private/New-ChocolateyCompletionResultForFeatureName.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Creates completion results for Chocolatey feature names.
+
+.DESCRIPTION
+    Gets configured Chocolatey feature names and turns them into PowerShell
+    completion results.
+
+.PARAMETER WordToComplete
+    Current token text that should be matched against feature names.
+
+.EXAMPLE
+    New-ChocolateyCompletionResultForFeatureName -WordToComplete 'show'
+#>
+function New-ChocolateyCompletionResultForFeatureName
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.CompletionResult[]])]
+    param
+    (
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]
+        $WordToComplete = ''
+    )
+
+    try
+    {
+        $featureNames = Get-ChocolateyFeature | Select-Object -ExpandProperty 'Name'
+        New-ChocolateyCompletionResult -Value $featureNames -WordToComplete $WordToComplete
+    }
+    catch [System.Management.Automation.CommandNotFoundException], [System.Management.Automation.ItemNotFoundException]
+    {
+        return
+    }
+}

--- a/source/private/New-ChocolateyCompletionResultForPackageName.ps1
+++ b/source/private/New-ChocolateyCompletionResultForPackageName.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Creates completion results for Chocolatey package names.
+
+.DESCRIPTION
+    Gets local Chocolatey package names and turns them into PowerShell
+    completion results.
+
+.PARAMETER WordToComplete
+    Current token text that should be matched against local package names.
+
+.EXAMPLE
+    New-ChocolateyCompletionResultForPackageName -WordToComplete 'git'
+#>
+function New-ChocolateyCompletionResultForPackageName
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.CompletionResult[]])]
+    param
+    (
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]
+        $WordToComplete = ''
+    )
+
+    try
+    {
+        $packageNames = Get-ChocolateyPackage | Select-Object -ExpandProperty 'Name'
+        New-ChocolateyCompletionResult -Value $packageNames -WordToComplete $WordToComplete
+    }
+    catch [System.Management.Automation.CommandNotFoundException], [System.Management.Automation.ItemNotFoundException]
+    {
+        return
+    }
+}

--- a/source/private/New-ChocolateyCompletionResultForPinName.ps1
+++ b/source/private/New-ChocolateyCompletionResultForPinName.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Creates completion results for Chocolatey pin names.
+
+.DESCRIPTION
+    Gets Chocolatey pin names and turns them into PowerShell completion
+    results.
+
+.PARAMETER WordToComplete
+    Current token text that should be matched against pin names.
+
+.EXAMPLE
+    New-ChocolateyCompletionResultForPinName -WordToComplete 'git'
+#>
+function New-ChocolateyCompletionResultForPinName
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.CompletionResult[]])]
+    param
+    (
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]
+        $WordToComplete = ''
+    )
+
+    try
+    {
+        $pinNames = Get-ChocolateyPin | Select-Object -ExpandProperty 'Name'
+        New-ChocolateyCompletionResult -Value $pinNames -WordToComplete $WordToComplete
+    }
+    catch [System.Management.Automation.CommandNotFoundException], [System.Management.Automation.ItemNotFoundException]
+    {
+        return
+    }
+}

--- a/source/private/New-ChocolateyCompletionResultForSettingName.ps1
+++ b/source/private/New-ChocolateyCompletionResultForSettingName.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Creates completion results for Chocolatey setting names.
+
+.DESCRIPTION
+    Gets configured Chocolatey setting names and turns them into PowerShell
+    completion results.
+
+.PARAMETER WordToComplete
+    Current token text that should be matched against setting names.
+
+.EXAMPLE
+    New-ChocolateyCompletionResultForSettingName -WordToComplete 'cache'
+#>
+function New-ChocolateyCompletionResultForSettingName
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.CompletionResult[]])]
+    param
+    (
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]
+        $WordToComplete = ''
+    )
+
+    try
+    {
+        $settingNames = Get-ChocolateySetting | Select-Object -ExpandProperty 'key'
+        New-ChocolateyCompletionResult -Value $settingNames -WordToComplete $WordToComplete
+    }
+    catch [System.Management.Automation.CommandNotFoundException], [System.Management.Automation.ItemNotFoundException]
+    {
+        return
+    }
+}

--- a/source/private/New-ChocolateyCompletionResultForSourceName.ps1
+++ b/source/private/New-ChocolateyCompletionResultForSourceName.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Creates completion results for Chocolatey source names.
+
+.DESCRIPTION
+    Gets configured Chocolatey source names and turns them into PowerShell
+    completion results.
+
+.PARAMETER WordToComplete
+    Current token text that should be matched against source names.
+
+.EXAMPLE
+    New-ChocolateyCompletionResultForSourceName -WordToComplete 'int'
+#>
+function New-ChocolateyCompletionResultForSourceName
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.CompletionResult[]])]
+    param
+    (
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]
+        $WordToComplete = ''
+    )
+
+    try
+    {
+        $sourceNames = Get-ChocolateySource | Select-Object -ExpandProperty 'Name'
+        New-ChocolateyCompletionResult -Value $sourceNames -WordToComplete $WordToComplete
+    }
+    catch [System.Management.Automation.CommandNotFoundException], [System.Management.Automation.ItemNotFoundException]
+    {
+        return
+    }
+}

--- a/source/private/Register-ChocolateyArgumentCompleter.ps1
+++ b/source/private/Register-ChocolateyArgumentCompleter.ps1
@@ -1,0 +1,187 @@
+<#
+.SYNOPSIS
+    Registers Chocolatey argument completers for PowerShell commands.
+
+.DESCRIPTION
+    Adds PowerShell-native argument completers for Chocolatey wrapper commands
+    by registering scriptblocks that defer to focused completion-result helpers.
+
+.EXAMPLE
+    Register-ChocolateyArgumentCompleter
+#>
+function Register-ChocolateyArgumentCompleter
+{
+    [CmdletBinding()]
+    [OutputType([void])]
+    param
+    ()
+
+    $packageNameCompleter = {
+        param
+        (
+            [Parameter()]
+            [string]
+            $CommandName,
+
+            [Parameter()]
+            [string]
+            $ParameterName,
+
+            [Parameter()]
+            [string]
+            $WordToComplete,
+
+            [Parameter()]
+            [System.Management.Automation.Language.CommandAst]
+            $CommandAst,
+
+            [Parameter()]
+            [System.Collections.IDictionary]
+            $FakeBoundParameters
+        )
+
+        New-ChocolateyCompletionResultForPackageName -WordToComplete $WordToComplete
+    }
+
+    $pinNameCompleter = {
+        param
+        (
+            [Parameter()]
+            [string]
+            $CommandName,
+
+            [Parameter()]
+            [string]
+            $ParameterName,
+
+            [Parameter()]
+            [string]
+            $WordToComplete,
+
+            [Parameter()]
+            [System.Management.Automation.Language.CommandAst]
+            $CommandAst,
+
+            [Parameter()]
+            [System.Collections.IDictionary]
+            $FakeBoundParameters
+        )
+
+        New-ChocolateyCompletionResultForPinName -WordToComplete $WordToComplete
+    }
+
+    $sourceNameCompleter = {
+        param
+        (
+            [Parameter()]
+            [string]
+            $CommandName,
+
+            [Parameter()]
+            [string]
+            $ParameterName,
+
+            [Parameter()]
+            [string]
+            $WordToComplete,
+
+            [Parameter()]
+            [System.Management.Automation.Language.CommandAst]
+            $CommandAst,
+
+            [Parameter()]
+            [System.Collections.IDictionary]
+            $FakeBoundParameters
+        )
+
+        New-ChocolateyCompletionResultForSourceName -WordToComplete $WordToComplete
+    }
+
+    $featureNameCompleter = {
+        param
+        (
+            [Parameter()]
+            [string]
+            $CommandName,
+
+            [Parameter()]
+            [string]
+            $ParameterName,
+
+            [Parameter()]
+            [string]
+            $WordToComplete,
+
+            [Parameter()]
+            [System.Management.Automation.Language.CommandAst]
+            $CommandAst,
+
+            [Parameter()]
+            [System.Collections.IDictionary]
+            $FakeBoundParameters
+        )
+
+        New-ChocolateyCompletionResultForFeatureName -WordToComplete $WordToComplete
+    }
+
+    $settingNameCompleter = {
+        param
+        (
+            [Parameter()]
+            [string]
+            $CommandName,
+
+            [Parameter()]
+            [string]
+            $ParameterName,
+
+            [Parameter()]
+            [string]
+            $WordToComplete,
+
+            [Parameter()]
+            [System.Management.Automation.Language.CommandAst]
+            $CommandAst,
+
+            [Parameter()]
+            [System.Collections.IDictionary]
+            $FakeBoundParameters
+        )
+
+        New-ChocolateyCompletionResultForSettingName -WordToComplete $WordToComplete
+    }
+
+    Register-ArgumentCompleter -CommandName @(
+        'Get-ChocolateyPackage',
+        'Uninstall-ChocolateyPackage',
+        'Update-ChocolateyPackage',
+        'Add-ChocolateyPin'
+    ) -ParameterName 'Name' -ScriptBlock $packageNameCompleter
+
+    Register-ArgumentCompleter -CommandName @(
+        'Get-ChocolateyPin',
+        'Remove-ChocolateyPin',
+        'Test-ChocolateyPin'
+    ) -ParameterName 'Name' -ScriptBlock $pinNameCompleter
+
+    Register-ArgumentCompleter -CommandName @(
+        'Get-ChocolateySource',
+        'Test-ChocolateySource',
+        'Enable-ChocolateySource',
+        'Disable-ChocolateySource',
+        'Unregister-ChocolateySource'
+    ) -ParameterName 'Name' -ScriptBlock $sourceNameCompleter
+
+    Register-ArgumentCompleter -CommandName 'Get-ChocolateyFeature' -ParameterName 'Feature' -ScriptBlock $featureNameCompleter
+    Register-ArgumentCompleter -CommandName @(
+        'Test-ChocolateyFeature',
+        'Enable-ChocolateyFeature',
+        'Disable-ChocolateyFeature'
+    ) -ParameterName 'Name' -ScriptBlock $featureNameCompleter
+
+    Register-ArgumentCompleter -CommandName 'Get-ChocolateySetting' -ParameterName 'Setting' -ScriptBlock $settingNameCompleter
+    Register-ArgumentCompleter -CommandName @(
+        'Test-ChocolateySetting',
+        'Set-ChocolateySetting'
+    ) -ParameterName 'Name' -ScriptBlock $settingNameCompleter
+}

--- a/source/suffix.ps1
+++ b/source/suffix.ps1
@@ -86,3 +86,5 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
 }.GetNewClosure()
 
 #endregion
+
+Register-ChocolateyArgumentCompleter

--- a/tests/Unit/Private/New-ChocolateyCompletionResult.tests.ps1
+++ b/tests/Unit/Private/New-ChocolateyCompletionResult.tests.ps1
@@ -1,0 +1,52 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe New-ChocolateyCompletionResult {
+    Context 'When matching candidate values' {
+        BeforeAll {
+            $script:results = InModuleScope -ScriptBlock {
+                New-ChocolateyCompletionResult -Value @(
+                    'google chrome',
+                    'git',
+                    'git'
+                ) -WordToComplete 'g'
+            }
+        }
+
+        It 'Should return unique completion results' {
+            $script:results.Count | Should -Be 2
+            $script:results.ListItemText | Should -Be @('git', 'google chrome')
+        }
+
+        It 'Should quote completion text for values with spaces' {
+            ($script:results | Where-Object -FilterScript { $_.ListItemText -eq 'google chrome' }).CompletionText |
+                Should -Be "'google chrome'"
+        }
+    }
+
+    Context 'When filtering by the current word' {
+        It 'Should only return prefix matches' {
+            $result = InModuleScope -ScriptBlock {
+                New-ChocolateyCompletionResult -Value @(
+                    'git',
+                    'python'
+                ) -WordToComplete 'py'
+            }
+
+            $result.Count | Should -Be 1
+            $result[0].ListItemText | Should -Be 'python'
+        }
+    }
+}

--- a/tests/Unit/Private/New-ChocolateyCompletionResultForFeatureName.tests.ps1
+++ b/tests/Unit/Private/New-ChocolateyCompletionResultForFeatureName.tests.ps1
@@ -1,0 +1,53 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe New-ChocolateyCompletionResultForFeatureName {
+    It 'Should build completion results from feature names' {
+        $script:capturedValue = $null
+        $script:capturedWordToComplete = $null
+
+        Mock Get-ChocolateyFeature -MockWith {
+            @(
+                [PSCustomObject]@{ Name = 'checksumFiles' },
+                [PSCustomObject]@{ Name = 'showDownloadProgress' }
+            )
+        }
+        Mock New-ChocolateyCompletionResult -MockWith {
+            param
+            (
+                [Parameter()]
+                [string[]]
+                $Value,
+
+                [Parameter()]
+                [string]
+                $WordToComplete
+            )
+
+            $script:capturedValue = $Value
+            $script:capturedWordToComplete = $WordToComplete
+
+            'feature-completion'
+        }
+
+        $result = InModuleScope -ScriptBlock {
+            New-ChocolateyCompletionResultForFeatureName -WordToComplete 'show'
+        }
+        $result | Should -Be 'feature-completion'
+        $result | Should -Be 'feature-completion'
+        $script:capturedValue | Should -Be @('checksumFiles', 'showDownloadProgress')
+        $script:capturedWordToComplete | Should -Be 'show'
+    }
+}

--- a/tests/Unit/Private/New-ChocolateyCompletionResultForPackageName.tests.ps1
+++ b/tests/Unit/Private/New-ChocolateyCompletionResultForPackageName.tests.ps1
@@ -1,0 +1,53 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe New-ChocolateyCompletionResultForPackageName {
+    It 'Should build completion results from package names' {
+        $script:capturedValue = $null
+        $script:capturedWordToComplete = $null
+
+        Mock Get-ChocolateyPackage -MockWith {
+            @(
+                [PSCustomObject]@{ Name = 'git' },
+                [PSCustomObject]@{ Name = 'googlechrome' }
+            )
+        }
+        Mock New-ChocolateyCompletionResult -MockWith {
+            param
+            (
+                [Parameter()]
+                [string[]]
+                $Value,
+
+                [Parameter()]
+                [string]
+                $WordToComplete
+            )
+
+            $script:capturedValue = $Value
+            $script:capturedWordToComplete = $WordToComplete
+
+            'package-completion'
+        }
+
+        $result = InModuleScope -ScriptBlock {
+            New-ChocolateyCompletionResultForPackageName -WordToComplete 'go'
+        }
+        $result | Should -Be 'package-completion'
+        $result | Should -Be 'package-completion'
+        $script:capturedValue | Should -Be @('git', 'googlechrome')
+        $script:capturedWordToComplete | Should -Be 'go'
+    }
+}

--- a/tests/Unit/Private/New-ChocolateyCompletionResultForPinName.tests.ps1
+++ b/tests/Unit/Private/New-ChocolateyCompletionResultForPinName.tests.ps1
@@ -1,0 +1,53 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe New-ChocolateyCompletionResultForPinName {
+    It 'Should build completion results from pin names' {
+        $script:capturedValue = $null
+        $script:capturedWordToComplete = $null
+
+        Mock Get-ChocolateyPin -MockWith {
+            @(
+                [PSCustomObject]@{ Name = 'git' },
+                [PSCustomObject]@{ Name = 'googlechrome' }
+            )
+        }
+        Mock New-ChocolateyCompletionResult -MockWith {
+            param
+            (
+                [Parameter()]
+                [string[]]
+                $Value,
+
+                [Parameter()]
+                [string]
+                $WordToComplete
+            )
+
+            $script:capturedValue = $Value
+            $script:capturedWordToComplete = $WordToComplete
+
+            'pin-completion'
+        }
+
+        $result = InModuleScope -ScriptBlock {
+            New-ChocolateyCompletionResultForPinName -WordToComplete 'g'
+        }
+        $result | Should -Be 'pin-completion'
+        $result | Should -Be 'pin-completion'
+        $script:capturedValue | Should -Be @('git', 'googlechrome')
+        $script:capturedWordToComplete | Should -Be 'g'
+    }
+}

--- a/tests/Unit/Private/New-ChocolateyCompletionResultForSettingName.tests.ps1
+++ b/tests/Unit/Private/New-ChocolateyCompletionResultForSettingName.tests.ps1
@@ -1,0 +1,53 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe New-ChocolateyCompletionResultForSettingName {
+    It 'Should build completion results from setting names' {
+        $script:capturedValue = $null
+        $script:capturedWordToComplete = $null
+
+        Mock Get-ChocolateySetting -MockWith {
+            @(
+                [PSCustomObject]@{ key = 'cacheLocation' },
+                [PSCustomObject]@{ key = 'commandExecutionTimeoutSeconds' }
+            )
+        }
+        Mock New-ChocolateyCompletionResult -MockWith {
+            param
+            (
+                [Parameter()]
+                [string[]]
+                $Value,
+
+                [Parameter()]
+                [string]
+                $WordToComplete
+            )
+
+            $script:capturedValue = $Value
+            $script:capturedWordToComplete = $WordToComplete
+
+            'setting-completion'
+        }
+
+        $result = InModuleScope -ScriptBlock {
+            New-ChocolateyCompletionResultForSettingName -WordToComplete 'cache'
+        }
+        $result | Should -Be 'setting-completion'
+        $result | Should -Be 'setting-completion'
+        $script:capturedValue | Should -Be @('cacheLocation', 'commandExecutionTimeoutSeconds')
+        $script:capturedWordToComplete | Should -Be 'cache'
+    }
+}

--- a/tests/Unit/Private/New-ChocolateyCompletionResultForSourceName.tests.ps1
+++ b/tests/Unit/Private/New-ChocolateyCompletionResultForSourceName.tests.ps1
@@ -1,0 +1,53 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe New-ChocolateyCompletionResultForSourceName {
+    It 'Should build completion results from source names' {
+        $script:capturedValue = $null
+        $script:capturedWordToComplete = $null
+
+        Mock Get-ChocolateySource -MockWith {
+            @(
+                [PSCustomObject]@{ Name = 'Chocolatey' },
+                [PSCustomObject]@{ Name = 'Internal' }
+            )
+        }
+        Mock New-ChocolateyCompletionResult -MockWith {
+            param
+            (
+                [Parameter()]
+                [string[]]
+                $Value,
+
+                [Parameter()]
+                [string]
+                $WordToComplete
+            )
+
+            $script:capturedValue = $Value
+            $script:capturedWordToComplete = $WordToComplete
+
+            'source-completion'
+        }
+
+        $result = InModuleScope -ScriptBlock {
+            New-ChocolateyCompletionResultForSourceName -WordToComplete 'Int'
+        }
+        $result | Should -Be 'source-completion'
+        $result | Should -Be 'source-completion'
+        $script:capturedValue | Should -Be @('Chocolatey', 'Internal')
+        $script:capturedWordToComplete | Should -Be 'Int'
+    }
+}

--- a/tests/Unit/Private/Register-ChocolateyArgumentCompleter.tests.ps1
+++ b/tests/Unit/Private/Register-ChocolateyArgumentCompleter.tests.ps1
@@ -49,23 +49,23 @@ Describe Register-ChocolateyArgumentCompleter {
         It 'Should register the expected command and parameter combinations' {
             $script:registrations.Count | Should -Be 7
 
-            ($script:registrations | Where-Object -FilterScript {
+            @($script:registrations | Where-Object -FilterScript {
                 $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Update-ChocolateyPackage'
             }).Count | Should -Be 1
 
-            ($script:registrations | Where-Object -FilterScript {
+            @($script:registrations | Where-Object -FilterScript {
                 $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Remove-ChocolateyPin'
             }).Count | Should -Be 1
 
-            ($script:registrations | Where-Object -FilterScript {
+            @($script:registrations | Where-Object -FilterScript {
                 $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Unregister-ChocolateySource'
             }).Count | Should -Be 1
 
-            ($script:registrations | Where-Object -FilterScript {
+            @($script:registrations | Where-Object -FilterScript {
                 $_.ParameterName -eq 'Feature' -and $_.CommandName -contains 'Get-ChocolateyFeature'
             }).Count | Should -Be 1
 
-            ($script:registrations | Where-Object -FilterScript {
+            @($script:registrations | Where-Object -FilterScript {
                 $_.ParameterName -eq 'Setting' -and $_.CommandName -contains 'Get-ChocolateySetting'
             }).Count | Should -Be 1
         }

--- a/tests/Unit/Private/Register-ChocolateyArgumentCompleter.tests.ps1
+++ b/tests/Unit/Private/Register-ChocolateyArgumentCompleter.tests.ps1
@@ -1,0 +1,121 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Register-ChocolateyArgumentCompleter {
+    Context 'When registering completers' {
+        BeforeEach {
+            $script:registrations = @()
+
+            Mock Register-ArgumentCompleter -MockWith {
+                param
+                (
+                    [Parameter()]
+                    [string[]]
+                    $CommandName,
+
+                    [Parameter()]
+                    [string]
+                    $ParameterName,
+
+                    [Parameter()]
+                    [scriptblock]
+                    $ScriptBlock
+                )
+
+                $script:registrations += [PSCustomObject]@{
+                    CommandName   = $CommandName
+                    ParameterName = $ParameterName
+                    ScriptBlock   = $ScriptBlock
+                }
+            }
+
+            InModuleScope -ScriptBlock {
+                Register-ChocolateyArgumentCompleter
+            }
+        }
+
+        It 'Should register the expected command and parameter combinations' {
+            $script:registrations.Count | Should -Be 7
+
+            ($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Update-ChocolateyPackage'
+            }).Count | Should -Be 1
+
+            ($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Remove-ChocolateyPin'
+            }).Count | Should -Be 1
+
+            ($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Unregister-ChocolateySource'
+            }).Count | Should -Be 1
+
+            ($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Feature' -and $_.CommandName -contains 'Get-ChocolateyFeature'
+            }).Count | Should -Be 1
+
+            ($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Setting' -and $_.CommandName -contains 'Get-ChocolateySetting'
+            }).Count | Should -Be 1
+        }
+
+        It 'Should use the package completion helper for package commands' {
+            Mock New-ChocolateyCompletionResultForPackageName -MockWith { 'package-result' }
+
+            $registration = $script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Get-ChocolateyPackage'
+            } | Select-Object -First 1
+
+            $result = InModuleScope -ScriptBlock {
+                param
+                (
+                    [Parameter()]
+                    [scriptblock]
+                    $ScriptBlock
+                )
+
+                & $ScriptBlock 'Get-ChocolateyPackage' 'Name' 'go' $null @{}
+            } -Parameters @{ ScriptBlock = $registration.ScriptBlock }
+
+            $result | Should -Be 'package-result'
+            Should -Invoke New-ChocolateyCompletionResultForPackageName -Times 1 -Exactly -ParameterFilter {
+                $WordToComplete -eq 'go'
+            }
+        }
+
+        It 'Should use the feature completion helper for feature commands' {
+            Mock New-ChocolateyCompletionResultForFeatureName -MockWith { 'feature-result' }
+
+            $registration = $script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Feature'
+            } | Select-Object -First 1
+
+            $result = InModuleScope -ScriptBlock {
+                param
+                (
+                    [Parameter()]
+                    [scriptblock]
+                    $ScriptBlock
+                )
+
+                & $ScriptBlock 'Get-ChocolateyFeature' 'Feature' 'show' $null @{}
+            } -Parameters @{ ScriptBlock = $registration.ScriptBlock }
+
+            $result | Should -Be 'feature-result'
+            Should -Invoke New-ChocolateyCompletionResultForFeatureName -Times 1 -Exactly -ParameterFilter {
+                $WordToComplete -eq 'show'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces PowerShell argument completers for Chocolatey wrapper commands, improving the user experience by enabling tab completion for local package, pin, source, feature, and setting names. It also documents these enhancements and adds comprehensive unit tests. Additionally, the PR updates internal coding standards for parameter formatting in both public and private functions.

**PowerShell argument completer enhancements:**

* Added registration of PowerShell argument completers for Chocolatey commands, enabling local-only tab completion for package, pin, source, feature, and setting names. The completers are registered on module import and do not query remote feeds, ensuring responsiveness. (`source/private/Register-ChocolateyArgumentCompleter.ps1`, `source/suffix.ps1`, `README.md`, `CHANGELOG.md`, `source/WikiSource/ArgumentCompleters.md`, `source/WikiSource/Home.md`) [[1]](diffhunk://#diff-d163ffe0221a9bd0eed9a77c6fcd4ded7c1c371860d5399681a5a33f0de6399dR1-R187) [[2]](diffhunk://#diff-adbf860ad62e76c7478cb3f6fe2820bdc486aa8616581b5511ad2376b94b0829R89-R90) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R46) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR38-R39) [[5]](diffhunk://#diff-b7bdfc9da2da3abaa07b531fc0d396c0f99a8d569e15529efd2e29d075851a93R1-R36) [[6]](diffhunk://#diff-4ff689846f9c896ab4e3598f4348bcdd256f5966427b380618864283b182ff93R13)

* Implemented helper functions to generate completion results for each argument type: packages, pins, sources, features, and settings. Each helper retrieves local state and produces filtered, quoted completion results as needed. (`source/private/New-ChocolateyCompletionResult.ps1`, `source/private/New-ChocolateyCompletionResultForPackageName.ps1`, `source/private/New-ChocolateyCompletionResultForPinName.ps1`, `source/private/New-ChocolateyCompletionResultForSourceName.ps1`, `source/private/New-ChocolateyCompletionResultForFeatureName.ps1`, `source/private/New-ChocolateyCompletionResultForSettingName.ps1`) [[1]](diffhunk://#diff-9ac8d4753cd8f3fbac799a26f33fe486ccbb7844a2819aeca1f0973c84e1cc0fR1-R63) [[2]](diffhunk://#diff-c166393b76f939e494065d7a255d604854246e3f7f4f229c1529058fd948081fR1-R36) [[3]](diffhunk://#diff-69f18c1bb1e7ae8d216a4948c718f48d31088de718c4b47068c31a82f2bdf7b2R1-R36) [[4]](diffhunk://#diff-df336a11bb4f7d3dea54dd21fbe572d6b3e112f05772e879b21a0b8fe5931d79R1-R36) [[5]](diffhunk://#diff-37db7b206acafdbc526380e250cf82b160bdb8219d13b6160419d4b8edc56e5eR1-R36) [[6]](diffhunk://#diff-8d41ea93f7c29e94f78bee4264d92df09e3216554393c96a11489826ac9a2be7R1-R36)

**Documentation updates:**

* Added new documentation pages and updated the README and wiki home to describe argument completer support and usage examples. (`README.md`, `source/WikiSource/ArgumentCompleters.md`, `source/WikiSource/Home.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R46) [[2]](diffhunk://#diff-b7bdfc9da2da3abaa07b531fc0d396c0f99a8d569e15529efd2e29d075851a93R1-R36) [[3]](diffhunk://#diff-4ff689846f9c896ab4e3598f4348bcdd256f5966427b380618864283b182ff93R13)

**Testing improvements:**

* Added unit tests for completion result helpers to ensure correct filtering, quoting, and integration with local Chocolatey state. (`tests/Unit/Private/New-ChocolateyCompletionResult.tests.ps1`, `tests/Unit/Private/New-ChocolateyCompletionResultForFeatureName.tests.ps1`) [[1]](diffhunk://#diff-97454cfd680d8e46a9baf5b069ada90fe00584e4d28085e2d28c8508facc0db2R1-R52) [[2]](diffhunk://#diff-9a97d942e372c29ab86af3f077ee22483cd0f2b7da6474ff10a6b641796a39d1R1-R53)

**Coding standards updates:**

* Updated coding instructions for public and private functions to require `[Parameter()]` on every parameter and standardized parameter formatting for clarity and consistency. (`.github/instructions/public-functions.instructions.md`, `.github/instructions/private-functions.instructions.md`) [[1]](diffhunk://#diff-496df50ecbc4c67e85b8f06f770d4ec25be2d65ad469f25e8954c8c150185a8dR16-R17) [[2]](diffhunk://#diff-48854c2cae4c8cc8a888b069a635528c8014edfd60f460831fc56b90d412e254R12-R13)