### PR TITLE
Add Publish-ChocolateyPackage function

### DIFF
--- a/.github/instructions/test-writing.instructions.md
+++ b/.github/instructions/test-writing.instructions.md
@@ -47,6 +47,7 @@ BeforeAll {
 - Use PowerShell-version or platform guards only when the behavior truly differs between Windows PowerShell 5.1 and PowerShell 7.
 - This repository is Windows-only, but tests must still work on both supported PowerShell versions.
 - For commands that mutate system state and use the hidden `RunNonElevated` parameter defaulted from `Assert-ChocolateyIsElevated`, unit tests should normally pass `-RunNonElevated` unless the elevation check itself is the subject of the test.
+- For commands that use `SupportsShouldProcess`, pass `-Confirm:$false` in unit tests that are meant to exercise the execution path. Do not rely on `ConfirmImpact` being low enough to skip the prompt — `$ConfirmPreference` may vary across environments and PowerShell versions, and non-interactive mode throws when a prompt would be shown.
 - Mock the command-discovery helper that the implementation actually uses. In this repository that is usually `Get-ChocolateyCommand`, not `Get-Command`.
 
 ## Windows PowerShell 5.1 compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `Publish-ChocolateyPackage` public function wrapping `choco push` to publish `.nupkg` files to a Chocolatey-compatible feed, with support for `Source`, `ApiKey`, and standard common options.
+
 ### Changed
 
 - Added repository Copilot setup and instructions covering cloud-agent bootstrap,

--- a/source/public/package/Publish-ChocolateyPackage.ps1
+++ b/source/public/package/Publish-ChocolateyPackage.ps1
@@ -1,0 +1,191 @@
+<#
+.SYNOPSIS
+    Pushes a Chocolatey package file to a source feed.
+
+.DESCRIPTION
+    Wraps `choco push` to publish one or more `.nupkg` files to a Chocolatey-compatible
+    package feed. Requires a source URL and, for authenticated feeds such as the
+    Chocolatey Community Repository, an API key.
+
+.PARAMETER Path
+    Path to the `.nupkg` file to publish. Accepts pipeline input and multiple values.
+
+.PARAMETER Source
+    Source feed URL to push the package to. Required for the Chocolatey Community
+    Repository (https://push.chocolatey.org/).
+
+.PARAMETER ApiKey
+    API key for the target source feed.
+
+.PARAMETER Force
+    Force the push behavior.
+
+.PARAMETER CacheLocation
+    Location for Chocolatey's download cache.
+
+.PARAMETER NoProgress
+    Do not show progress percentages.
+
+.PARAMETER Timeout
+    Command execution timeout in seconds. Use `0` for infinite timeout.
+
+.PARAMETER ProxyLocation
+    Explicit proxy location to use for the Chocolatey command.
+
+.PARAMETER ProxyCredential
+    Credential to authenticate to the proxy.
+
+.PARAMETER ProxyBypassList
+    Regular-expression list of hosts that should bypass the proxy.
+
+.PARAMETER ProxyBypassOnLocal
+    Bypass the proxy for local connections.
+
+.PARAMETER AllowUnofficialBuild
+    Allow the command to run when using an unofficial Chocolatey build.
+
+.PARAMETER FailOnStandardError
+    Fail if Chocolatey writes to the standard error stream.
+
+.PARAMETER UseSystemPowerShell
+    Run PowerShell in an external process instead of the embedded host.
+
+.PARAMETER SkipCompatibilityChecks
+    Skip Chocolatey and licensed extension compatibility warnings.
+
+.PARAMETER IgnoreHttpCache
+    Ignore cached HTTP responses.
+
+.EXAMPLE
+    Publish-ChocolateyPackage -Path '.\mypackage.1.0.0.nupkg' -Source 'https://push.chocolatey.org/' -ApiKey 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+
+    Pushes mypackage 1.0.0 to the Chocolatey Community Repository.
+
+.EXAMPLE
+    Publish-ChocolateyPackage -Path '.\mypackage.1.0.0.nupkg' -Source 'https://proget.example.com/nuget/choco/'
+
+    Pushes the package to an internal ProGet feed (no API key needed if the feed allows anonymous push).
+
+.EXAMPLE
+    Get-ChildItem -Path '.\output\' -Filter '*.nupkg' | Select-Object -ExpandProperty FullName | Publish-ChocolateyPackage -Source 'https://internalrepo/nuget/choco/'
+
+    Publishes every nupkg in the output folder via pipeline.
+
+.NOTES
+    https://docs.chocolatey.org/en-us/choco/commands/push/
+#>
+function Publish-ChocolateyPackage
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.String[]]
+        $Path,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $Source,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $ApiKey,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Force,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $CacheLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $NoProgress,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [int]
+        $Timeout,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ProxyLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [PSCredential]
+        $ProxyCredential,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string[]]
+        $ProxyBypassList,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ProxyBypassOnLocal,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AllowUnofficialBuild,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $FailOnStandardError,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $UseSystemPowerShell,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $SkipCompatibilityChecks,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreHttpCache
+    )
+
+    begin
+    {
+        $chocoCmd = Get-ChocolateyCommand
+    }
+
+    process
+    {
+        $defaultArgParameters = @{}
+        foreach ($key in $PSBoundParameters.Keys)
+        {
+            if ($key -notin 'Path', 'ApiKey')
+            {
+                $defaultArgParameters[$key] = $PSBoundParameters[$key]
+            }
+        }
+
+        foreach ($nupkg in $Path)
+        {
+            [System.Collections.Generic.List[string]] $chocoArguments = [System.Collections.Generic.List[string]]::new()
+            $chocoArguments.Add('push')
+            $chocoArguments.Add($nupkg)
+
+            foreach ($argument in (Get-ChocolateyDefaultArgument @defaultArgParameters))
+            {
+                $chocoArguments.Add($argument)
+            }
+
+            if ($PSBoundParameters.ContainsKey('ApiKey'))
+            {
+                $chocoArguments.Add("--api-key=`"$ApiKey`"")
+            }
+
+            if ($PSCmdlet.ShouldProcess($nupkg, 'Publish Chocolatey package'))
+            {
+                $chocoArguments.Add('-y')
+                Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
+                &$chocoCmd @chocoArguments | ForEach-Object -Process {
+                    Write-Verbose -Message ('{0}' -f $_)
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/Publish-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Publish-ChocolateyPackage.tests.ps1
@@ -1,0 +1,112 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Publish-ChocolateyPackage {
+    Context 'Default' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'pushed package'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should call Get-ChocolateyCommand' {
+            $null = Publish-ChocolateyPackage -Path 'mypackage.1.0.0.nupkg' -Confirm:$false
+
+            Should -Invoke Get-ChocolateyCommand -Times 1 -Exactly
+        }
+
+        It 'Should not return a value' {
+            $result = Publish-ChocolateyPackage -Path 'mypackage.1.0.0.nupkg' -Confirm:$false
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should pass push as the first choco argument' {
+            $null = Publish-ChocolateyPackage -Path 'mypackage.1.0.0.nupkg' -Confirm:$false
+
+            $script:capturedArguments[0] | Should -Be 'push'
+        }
+
+        It 'Should pass the nupkg path as the second choco argument' {
+            $null = Publish-ChocolateyPackage -Path 'mypackage.1.0.0.nupkg' -Confirm:$false
+
+            $script:capturedArguments[1] | Should -Be 'mypackage.1.0.0.nupkg'
+        }
+
+        It 'Should pass -y when confirmed' {
+            $null = Publish-ChocolateyPackage -Path 'mypackage.1.0.0.nupkg' -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '-y'
+        }
+
+        It 'Should include the source argument when Source is specified' {
+            $null = Publish-ChocolateyPackage -Path 'mypackage.1.0.0.nupkg' -Source 'https://push.chocolatey.org/' -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '-s"https://push.chocolatey.org/"'
+        }
+
+        It 'Should include the api-key argument when ApiKey is specified' {
+            $null = Publish-ChocolateyPackage -Path 'mypackage.1.0.0.nupkg' -ApiKey 'my-api-key' -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--api-key="my-api-key"'
+        }
+
+        It 'Should not include --api-key when ApiKey is not specified' {
+            $null = Publish-ChocolateyPackage -Path 'mypackage.1.0.0.nupkg' -Confirm:$false
+
+            $script:capturedArguments | Should -Not -Contain '--api-key'
+            @($script:capturedArguments | Where-Object -FilterScript { $_ -like '--api-key*' }).Count | Should -Be 0
+        }
+
+        It 'Should publish each package when multiple paths are supplied' {
+            $null = Publish-ChocolateyPackage -Path 'pkg1.nupkg', 'pkg2.nupkg' -Confirm:$false
+
+            Should -Invoke Get-ChocolateyCommand -Times 1 -Exactly
+        }
+
+        It 'Should not execute when WhatIf is specified' {
+            $null = Publish-ChocolateyPackage -Path 'mypackage.1.0.0.nupkg' -WhatIf
+
+            $script:capturedArguments | Should -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new public function for publishing Chocolatey packages, along with corresponding unit tests and documentation updates. The main focus is to provide a streamlined, scriptable way to push `.nupkg` files to Chocolatey-compatible feeds, supporting common options and authentication. Additionally, the documentation and test-writing instructions are improved for clarity and reliability.

**New Feature: Chocolatey Package Publishing**

* Added a new public function `Publish-ChocolateyPackage` that wraps `choco push` to publish `.nupkg` files to a Chocolatey-compatible feed. This function supports parameters for `Source`, `ApiKey`, and other standard options, and is documented with usage examples and notes.
* Added comprehensive unit tests for `Publish-ChocolateyPackage`, verifying command construction, parameter handling, and correct invocation logic.
* Documented the new function in the changelog under the "Added" section.

**Test and Documentation Improvements**

* Updated test-writing instructions to require passing `-Confirm:$false` in unit tests for commands using `SupportsShouldProcess`, ensuring tests are robust against environment and PowerShell version differences.