### PR TITLE
Add Optimize, Sync, Convert-ChocolateyPackage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,11 @@
 # Copilot instructions for Chocolatey
 
+## Git workflow
+
+- Never run `git commit`, `git push`, or `git tag`. Leave all commits to the user.
+- Stage changes with `git add` only when explicitly asked to prepare a commit.
+- After completing work, summarize what changed so the user can review with `git diff` before committing.
+
 ## Build entrypoint
 
 - Use `./build.ps1` for all dependency restore, build, test, and validation work.

--- a/.github/instructions/public-functions.instructions.md
+++ b/.github/instructions/public-functions.instructions.md
@@ -40,3 +40,18 @@ applyTo: 'source/public/**/*.ps1'
 ```
 
 - User-visible behavior changes require an `Unreleased` changelog entry.
+
+## Argument completers
+
+When a new public function accepts parameters that map to known Chocolatey objects, register completers in `source/private/Register-ChocolateyArgumentCompleter.ps1`:
+
+| Parameter name | Typical usage | Completer helper |
+|---|---|---|
+| `-Name` (installed package id) | `Optimize-`, `Uninstall-`, `Update-`, `Compare-ChocolateyPackage`, `Add-ChocolateyPin` | `$packageNameCompleter` |
+| `-Name` (pin name) | `Get-`, `Remove-`, `Test-ChocolateyPin` | `$pinNameCompleter` |
+| `-Name` or `-Source` (source name) | `Get-`, `Enable-`, `Disable-`, `Unregister-ChocolateySource` | `$sourceNameCompleter` |
+| `-Source` (package operation) | `Install-`, `Update-`, `Uninstall-`, `Save-`, `Find-`, `Compare-`, `Publish-ChocolateyPackage` | `$sourceNameCompleter` |
+| `-Name` / feature name | `Get-`, `Enable-`, `Disable-`, `Test-ChocolateyFeature` | `$featureNameCompleter` |
+| `-Name` / setting name | `Set-`, `Test-ChocolateySetting` | `$settingNameCompleter` |
+
+After updating the registration, update the count assertion and add a targeted assertion for the new command/parameter pair in `tests/Unit/Private/Register-ChocolateyArgumentCompleter.tests.ps1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `Publish-ChocolateyPackage` public function wrapping `choco push` to publish `.nupkg` files to a Chocolatey-compatible feed, with support for `Source`, `ApiKey`, and standard common options.
+- Added `Optimize-ChocolateyPackage` public function wrapping `choco optimize` (Licensed) to reduce disk space used by installed packages, with support for `Name` (per-package) and `ReduceNupkgOnly`.
+- Added `Sync-ChocolateyPackage` public function wrapping `choco sync` (C4B) to synchronize Chocolatey with software installed outside of Chocolatey, with support for `Id`, `PackageId`, and `OutputDirectory`.
+- Added `Convert-ChocolateyPackage` public function wrapping `choco convert` (C4B) to convert `.nupkg` files to other package formats (currently `intune`), with both per-path and `IncludeAll` modes.
 
 ### Changed
 

--- a/source/private/Register-ChocolateyArgumentCompleter.ps1
+++ b/source/private/Register-ChocolateyArgumentCompleter.ps1
@@ -152,11 +152,23 @@ function Register-ChocolateyArgumentCompleter
     }
 
     Register-ArgumentCompleter -CommandName @(
+        'Compare-ChocolateyPackage',
         'Get-ChocolateyPackage',
+        'Optimize-ChocolateyPackage',
         'Uninstall-ChocolateyPackage',
         'Update-ChocolateyPackage',
         'Add-ChocolateyPin'
     ) -ParameterName 'Name' -ScriptBlock $packageNameCompleter
+
+    Register-ArgumentCompleter -CommandName @(
+        'Compare-ChocolateyPackage',
+        'Find-ChocolateyPackage',
+        'Install-ChocolateyPackage',
+        'Publish-ChocolateyPackage',
+        'Save-ChocolateyPackage',
+        'Uninstall-ChocolateyPackage',
+        'Update-ChocolateyPackage'
+    ) -ParameterName 'Source' -ScriptBlock $sourceNameCompleter
 
     Register-ArgumentCompleter -CommandName @(
         'Get-ChocolateyPin',

--- a/source/public/package/Convert-ChocolateyPackage.ps1
+++ b/source/public/package/Convert-ChocolateyPackage.ps1
@@ -1,0 +1,234 @@
+<#
+.SYNOPSIS
+    Converts a Chocolatey package to another format.
+
+.DESCRIPTION
+    Wraps `choco convert` to convert a `.nupkg` file into a different package format.
+    Currently supports converting to Microsoft Intune (`.intunewin`) format.
+
+    This command requires Chocolatey for Business.
+
+.PARAMETER Path
+    Path to the `.nupkg` file to convert. Accepts pipeline input and multiple values.
+
+.PARAMETER IncludeAll
+    Convert all `.nupkg` files found in the current working directory.
+
+.PARAMETER ToFormat
+    Target format for the conversion. The only currently supported value is `intune`.
+
+.PARAMETER IgnoreDependencies
+    Ignore package dependencies during conversion.
+
+.PARAMETER ForceSelfService
+    Force the command to be handled through Chocolatey self-service when the feature
+    is enabled.
+
+.PARAMETER Force
+    Force the conversion behavior.
+
+.PARAMETER CacheLocation
+    Location for Chocolatey's download cache.
+
+.PARAMETER NoProgress
+    Do not show progress percentages.
+
+.PARAMETER Timeout
+    Command execution timeout in seconds. Use `0` for infinite timeout.
+
+.PARAMETER ProxyLocation
+    Explicit proxy location to use for the Chocolatey command.
+
+.PARAMETER ProxyCredential
+    Credential to authenticate to the proxy.
+
+.PARAMETER ProxyBypassList
+    Regular-expression list of hosts that should bypass the proxy.
+
+.PARAMETER ProxyBypassOnLocal
+    Bypass the proxy for local connections.
+
+.PARAMETER AllowUnofficialBuild
+    Allow the command to run when using an unofficial Chocolatey build.
+
+.PARAMETER FailOnStandardError
+    Fail if Chocolatey writes to the standard error stream.
+
+.PARAMETER UseSystemPowerShell
+    Run PowerShell in an external process instead of the embedded host.
+
+.PARAMETER SkipCompatibilityChecks
+    Skip Chocolatey and licensed extension compatibility warnings.
+
+.PARAMETER IgnoreHttpCache
+    Ignore cached HTTP responses.
+
+.EXAMPLE
+    Convert-ChocolateyPackage -Path 'sysinternals.2024.1.0.nupkg' -ToFormat intune
+
+    Converts the sysinternals nupkg to a Microsoft Intune package.
+
+.EXAMPLE
+    Convert-ChocolateyPackage -IncludeAll -ToFormat intune
+
+    Converts all `.nupkg` files in the current directory to Intune format.
+
+.EXAMPLE
+    Get-ChildItem -Filter '*.nupkg' | Select-Object -ExpandProperty FullName | Convert-ChocolateyPackage -ToFormat intune
+
+    Converts each nupkg found by pipeline to Intune format.
+
+.NOTES
+    https://docs.chocolatey.org/en-us/create/commands/convert/
+#>
+function Convert-ChocolateyPackage
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '')]
+    [CmdletBinding(DefaultParameterSetName = 'ByPath', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByPath', ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.String[]]
+        $Path,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AllInDirectory')]
+        [switch]
+        $IncludeAll,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('intune')]
+        [System.String]
+        $ToFormat,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreDependencies,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ForceSelfService,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Force,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $CacheLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $NoProgress,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [int]
+        $Timeout,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ProxyLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [PSCredential]
+        $ProxyCredential,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string[]]
+        $ProxyBypassList,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ProxyBypassOnLocal,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AllowUnofficialBuild,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $FailOnStandardError,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $UseSystemPowerShell,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $SkipCompatibilityChecks,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreHttpCache
+    )
+
+    begin
+    {
+        $chocoCmd = Get-ChocolateyCommand
+
+        $installDir = Get-ChocolateyInstallPath -ErrorAction 'Stop'
+        if (-not (Test-ChocolateyLicenseInstalled -InstallDir $installDir))
+        {
+            $licensePath = Join-Path -Path $installDir -ChildPath 'license\chocolatey.license.xml'
+            throw ("Convert-ChocolateyPackage requires a Chocolatey for Business license file at '{0}'." -f $licensePath)
+        }
+    }
+
+    process
+    {
+        $defaultArgParameters = @{}
+        foreach ($key in $PSBoundParameters.Keys)
+        {
+            if ($key -notin 'Path', 'IncludeAll', 'ToFormat')
+            {
+                $defaultArgParameters[$key] = $PSBoundParameters[$key]
+            }
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'AllInDirectory')
+        {
+            [System.Collections.Generic.List[string]] $chocoArguments = [System.Collections.Generic.List[string]]::new()
+            $chocoArguments.Add('convert')
+            $chocoArguments.Add("--to-format=`"$ToFormat`"")
+            $chocoArguments.Add('--include-all')
+
+            foreach ($argument in (Get-ChocolateyDefaultArgument @defaultArgParameters))
+            {
+                $chocoArguments.Add($argument)
+            }
+
+            if ($PSCmdlet.ShouldProcess('all packages in current directory', ('Convert to {0}' -f $ToFormat)))
+            {
+                $chocoArguments.Add('-y')
+                Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
+                &$chocoCmd @chocoArguments | ForEach-Object -Process {
+                    Write-Verbose -Message ('{0}' -f $_)
+                }
+            }
+        }
+        else
+        {
+            foreach ($nupkg in $Path)
+            {
+                [System.Collections.Generic.List[string]] $chocoArguments = [System.Collections.Generic.List[string]]::new()
+                $chocoArguments.Add('convert')
+                $chocoArguments.Add($nupkg)
+                $chocoArguments.Add("--to-format=`"$ToFormat`"")
+
+                foreach ($argument in (Get-ChocolateyDefaultArgument @defaultArgParameters))
+                {
+                    $chocoArguments.Add($argument)
+                }
+
+                if ($PSCmdlet.ShouldProcess($nupkg, ('Convert to {0}' -f $ToFormat)))
+                {
+                    $chocoArguments.Add('-y')
+                    Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
+                    &$chocoCmd @chocoArguments | ForEach-Object -Process {
+                        Write-Verbose -Message ('{0}' -f $_)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/source/public/package/Optimize-ChocolateyPackage.ps1
+++ b/source/public/package/Optimize-ChocolateyPackage.ps1
@@ -1,0 +1,232 @@
+<#
+.SYNOPSIS
+    Optimizes installed Chocolatey packages to reduce disk space usage.
+
+.DESCRIPTION
+    Wraps `choco optimize` to reduce the on-disk footprint of installed packages.
+    With Package Optimizer:
+
+    - Each `.nupkg` file is reduced to 5 KB or less.
+    - Zip and installer files are automatically removed from the package directory.
+    - Zip and installer files are removed from the TEMP cache.
+
+    This command requires Chocolatey Licensed Edition.
+
+.PARAMETER Name
+    Package id to optimize. When omitted, all installed packages are optimized.
+
+.PARAMETER ReduceNupkgOnly
+    Reduce only the size of the `.nupkg` file; leave downloaded installers in place.
+
+.PARAMETER ForceSelfService
+    Force the command to be handled through Chocolatey self-service when the feature
+    is enabled.
+
+.PARAMETER Force
+    Force the optimization behavior.
+
+.PARAMETER CacheLocation
+    Location for Chocolatey's download cache.
+
+.PARAMETER NoProgress
+    Do not show progress percentages.
+
+.PARAMETER Timeout
+    Command execution timeout in seconds. Use `0` for infinite timeout.
+
+.PARAMETER ProxyLocation
+    Explicit proxy location to use for the Chocolatey command.
+
+.PARAMETER ProxyCredential
+    Credential to authenticate to the proxy.
+
+.PARAMETER ProxyBypassList
+    Regular-expression list of hosts that should bypass the proxy.
+
+.PARAMETER ProxyBypassOnLocal
+    Bypass the proxy for local connections.
+
+.PARAMETER AllowUnofficialBuild
+    Allow the command to run when using an unofficial Chocolatey build.
+
+.PARAMETER FailOnStandardError
+    Fail if Chocolatey writes to the standard error stream.
+
+.PARAMETER UseSystemPowerShell
+    Run PowerShell in an external process instead of the embedded host.
+
+.PARAMETER SkipCompatibilityChecks
+    Skip Chocolatey and licensed extension compatibility warnings.
+
+.PARAMETER IgnoreHttpCache
+    Ignore cached HTTP responses.
+
+.PARAMETER RunNonElevated
+    Throws if the process is not running elevated. Use `-RunNonElevated` if you
+    really want to run even if the current shell is not elevated.
+
+.EXAMPLE
+    Optimize-ChocolateyPackage
+
+    Optimizes all installed packages, removing redundant installers and reducing
+    nupkg file sizes.
+
+.EXAMPLE
+    Optimize-ChocolateyPackage -Name 'googlechrome'
+
+    Optimizes only the googlechrome package.
+
+.EXAMPLE
+    Optimize-ChocolateyPackage -ReduceNupkgOnly
+
+    Reduces nupkg file sizes without removing downloaded installers.
+
+.NOTES
+    https://docs.chocolatey.org/en-us/choco/commands/optimize/
+#>
+function Optimize-ChocolateyPackage
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.String[]]
+        $Name,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ReduceNupkgOnly,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ForceSelfService,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Force,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $CacheLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $NoProgress,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [int]
+        $Timeout,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ProxyLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [PSCredential]
+        $ProxyCredential,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string[]]
+        $ProxyBypassList,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ProxyBypassOnLocal,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AllowUnofficialBuild,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $FailOnStandardError,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $UseSystemPowerShell,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $SkipCompatibilityChecks,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreHttpCache,
+
+        [Parameter(DontShow)]
+        [switch]
+        $RunNonElevated = $(Assert-ChocolateyIsElevated)
+    )
+
+    begin
+    {
+        $chocoCmd = Get-ChocolateyCommand
+
+        $installDir = Get-ChocolateyInstallPath -ErrorAction 'Stop'
+        if (-not (Test-ChocolateyLicenseInstalled -InstallDir $installDir))
+        {
+            $licensePath = Join-Path -Path $installDir -ChildPath 'license\chocolatey.license.xml'
+            throw ("Optimize-ChocolateyPackage requires a Chocolatey Licensed Edition license file at '{0}'." -f $licensePath)
+        }
+    }
+
+    process
+    {
+        $defaultArgParameters = @{}
+        foreach ($key in $PSBoundParameters.Keys)
+        {
+            if ($key -notin 'Name', 'ReduceNupkgOnly')
+            {
+                $defaultArgParameters[$key] = $PSBoundParameters[$key]
+            }
+        }
+
+        [System.Collections.Generic.List[string]] $baseArguments = [System.Collections.Generic.List[string]]::new()
+        $baseArguments.Add('optimize')
+
+        if ($ReduceNupkgOnly)
+        {
+            $baseArguments.Add('--reduce-nupkg-only')
+        }
+
+        foreach ($argument in (Get-ChocolateyDefaultArgument @defaultArgParameters))
+        {
+            $baseArguments.Add($argument)
+        }
+
+        if ($PSBoundParameters.ContainsKey('Name'))
+        {
+            foreach ($packageName in $Name)
+            {
+                [System.Collections.Generic.List[string]] $chocoArguments = [System.Collections.Generic.List[string]]::new()
+                foreach ($arg in $baseArguments) { $chocoArguments.Add($arg) }
+                $chocoArguments.Add("--id=`"$packageName`"")
+
+                if ($PSCmdlet.ShouldProcess($packageName, 'Optimize Chocolatey package'))
+                {
+                    $chocoArguments.Add('-y')
+                    Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
+                    &$chocoCmd @chocoArguments | ForEach-Object -Process {
+                        Write-Verbose -Message ('{0}' -f $_)
+                    }
+                }
+            }
+        }
+        else
+        {
+            [System.Collections.Generic.List[string]] $chocoArguments = [System.Collections.Generic.List[string]]::new()
+            foreach ($arg in $baseArguments) { $chocoArguments.Add($arg) }
+
+            if ($PSCmdlet.ShouldProcess('all installed packages', 'Optimize Chocolatey package'))
+            {
+                $chocoArguments.Add('-y')
+                Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
+                &$chocoCmd @chocoArguments | ForEach-Object -Process {
+                    Write-Verbose -Message ('{0}' -f $_)
+                }
+            }
+        }
+    }
+}

--- a/source/public/package/Save-ChocolateyPackage.ps1
+++ b/source/public/package/Save-ChocolateyPackage.ps1
@@ -9,6 +9,9 @@
     switches, and package internalization. Licensed-only parameters throw when
     no Chocolatey license file is installed.
 
+    Throws a terminating error when the choco output indicates that one or more
+    packages were not downloaded (output contains `not downloaded`).
+
 .PARAMETER Name
     Package name to save from the configured source or a specified source.
 
@@ -400,8 +403,17 @@ function Save-ChocolateyPackage
         {
             $chocoArguments.Add('-y')
             Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
-            &$chocoCmd @chocoArguments | ForEach-Object -Process {
-                Write-Verbose -Message ('{0}' -f $_)
+
+            $chocoOutput = &$chocoCmd @chocoArguments
+            foreach ($line in $chocoOutput)
+            {
+                Write-Verbose -Message ('{0}' -f $line)
+            }
+
+            $failedLines = @($chocoOutput | Where-Object { $_ -match 'not downloaded' })
+            if ($failedLines.Count -gt 0)
+            {
+                throw ('Chocolatey package download failed:{0}{1}' -f [System.Environment]::NewLine, ($failedLines -join [System.Environment]::NewLine))
             }
         }
     }

--- a/source/public/package/Sync-ChocolateyPackage.ps1
+++ b/source/public/package/Sync-ChocolateyPackage.ps1
@@ -1,0 +1,220 @@
+<#
+.SYNOPSIS
+    Synchronizes Chocolatey with software installed outside of Chocolatey.
+
+.DESCRIPTION
+    Wraps `choco sync` to scan the system for software that has been installed
+    outside Chocolatey, generates Chocolatey packages for those programs, and
+    baselines them against the Chocolatey package list.
+
+    This command requires Chocolatey for Business.
+
+.PARAMETER Id
+    Display Name of the software entry in Programs and Features to synchronize.
+    When omitted, all untracked software is synchronized.
+
+.PARAMETER PackageId
+    Custom Chocolatey package id to assign when synchronizing a specific program.
+    Used together with `-Id`. Requires Chocolatey for Business.
+
+.PARAMETER OutputDirectory
+    Directory where generated Chocolatey package files should be saved.
+
+.PARAMETER ForceSelfService
+    Force the command to be handled through Chocolatey self-service when the feature
+    is enabled.
+
+.PARAMETER Force
+    Force the sync behavior.
+
+.PARAMETER CacheLocation
+    Location for Chocolatey's download cache.
+
+.PARAMETER NoProgress
+    Do not show progress percentages.
+
+.PARAMETER Timeout
+    Command execution timeout in seconds. Use `0` for infinite timeout.
+
+.PARAMETER ProxyLocation
+    Explicit proxy location to use for the Chocolatey command.
+
+.PARAMETER ProxyCredential
+    Credential to authenticate to the proxy.
+
+.PARAMETER ProxyBypassList
+    Regular-expression list of hosts that should bypass the proxy.
+
+.PARAMETER ProxyBypassOnLocal
+    Bypass the proxy for local connections.
+
+.PARAMETER AllowUnofficialBuild
+    Allow the command to run when using an unofficial Chocolatey build.
+
+.PARAMETER FailOnStandardError
+    Fail if Chocolatey writes to the standard error stream.
+
+.PARAMETER UseSystemPowerShell
+    Run PowerShell in an external process instead of the embedded host.
+
+.PARAMETER SkipCompatibilityChecks
+    Skip Chocolatey and licensed extension compatibility warnings.
+
+.PARAMETER IgnoreHttpCache
+    Ignore cached HTTP responses.
+
+.PARAMETER RunNonElevated
+    Throws if the process is not running elevated. Use `-RunNonElevated` if you
+    really want to run even if the current shell is not elevated.
+
+.EXAMPLE
+    Sync-ChocolateyPackage
+
+    Synchronizes all software installed outside of Chocolatey.
+
+.EXAMPLE
+    Sync-ChocolateyPackage -Id 'Putty'
+
+    Synchronizes the Putty entry from Programs and Features into Chocolatey.
+
+.EXAMPLE
+    Sync-ChocolateyPackage -Id 'Putty' -PackageId 'putty.portable'
+
+    Synchronizes Putty and assigns it the custom package id 'putty.portable'.
+
+.NOTES
+    https://docs.chocolatey.org/en-us/choco/commands/sync/
+#>
+function Sync-ChocolateyPackage
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $Id,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $PackageId,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $OutputDirectory,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ForceSelfService,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $Force,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [System.String]
+        $CacheLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $NoProgress,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [int]
+        $Timeout,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $ProxyLocation,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [PSCredential]
+        $ProxyCredential,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string[]]
+        $ProxyBypassList,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $ProxyBypassOnLocal,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $AllowUnofficialBuild,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $FailOnStandardError,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $UseSystemPowerShell,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $SkipCompatibilityChecks,
+
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [switch]
+        $IgnoreHttpCache,
+
+        [Parameter(DontShow)]
+        [switch]
+        $RunNonElevated = $(Assert-ChocolateyIsElevated)
+    )
+
+    begin
+    {
+        $chocoCmd = Get-ChocolateyCommand
+
+        $installDir = Get-ChocolateyInstallPath -ErrorAction 'Stop'
+        if (-not (Test-ChocolateyLicenseInstalled -InstallDir $installDir))
+        {
+            $licensePath = Join-Path -Path $installDir -ChildPath 'license\chocolatey.license.xml'
+            throw ("Sync-ChocolateyPackage requires a Chocolatey for Business license file at '{0}'." -f $licensePath)
+        }
+    }
+
+    process
+    {
+        $defaultArgParameters = @{}
+        foreach ($key in $PSBoundParameters.Keys)
+        {
+            if ($key -notin 'Id', 'PackageId')
+            {
+                $defaultArgParameters[$key] = $PSBoundParameters[$key]
+            }
+        }
+
+        [System.Collections.Generic.List[string]] $chocoArguments = [System.Collections.Generic.List[string]]::new()
+        $chocoArguments.Add('sync')
+
+        if ($PSBoundParameters.ContainsKey('Id'))
+        {
+            $chocoArguments.Add("--id=`"$Id`"")
+        }
+
+        if ($PSBoundParameters.ContainsKey('PackageId'))
+        {
+            $chocoArguments.Add("--package-id=`"$PackageId`"")
+        }
+
+        foreach ($argument in (Get-ChocolateyDefaultArgument @defaultArgParameters))
+        {
+            $chocoArguments.Add($argument)
+        }
+
+        $target = if ($PSBoundParameters.ContainsKey('Id')) { $Id } else { 'all untracked software' }
+
+        if ($PSCmdlet.ShouldProcess($target, 'Sync Chocolatey package'))
+        {
+            $chocoArguments.Add('-y')
+            Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
+            &$chocoCmd @chocoArguments | ForEach-Object -Process {
+                Write-Verbose -Message ('{0}' -f $_)
+            }
+        }
+    }
+}

--- a/source/public/package/Sync-ChocolateyPackage.ps1
+++ b/source/public/package/Sync-ChocolateyPackage.ps1
@@ -7,6 +7,9 @@
     outside Chocolatey, generates Chocolatey packages for those programs, and
     baselines them against the Chocolatey package list.
 
+    Returns one `PSCustomObject` per synchronized entry with properties
+    `PackageId`, `DisplayName`, `Version`, and `NewPackage` (`[bool]`).
+
     This command requires Chocolatey for Business.
 
 .PARAMETER Id
@@ -89,7 +92,7 @@ function Sync-ChocolateyPackage
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '')]
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
-    [OutputType([void])]
+    [OutputType([PSCustomObject])]
     param
     (
         [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
@@ -212,8 +215,32 @@ function Sync-ChocolateyPackage
         {
             $chocoArguments.Add('-y')
             Write-Debug -Message ('{0} {1}' -f $chocoCmd, ($chocoArguments -join ' '))
-            &$chocoCmd @chocoArguments | ForEach-Object -Process {
-                Write-Verbose -Message ('{0}' -f $_)
+
+            $chocoOutput = &$chocoCmd @chocoArguments
+            $headers = $null
+
+            foreach ($line in $chocoOutput)
+            {
+                Write-Verbose -Message ('{0}' -f $line)
+
+                if ($line -notmatch '\|')
+                {
+                    continue
+                }
+
+                if ($null -eq $headers)
+                {
+                    $headers = $line -split '\|'
+                    continue
+                }
+
+                $values = $line -split '\|'
+                [PSCustomObject]@{
+                    PackageId   = $values[0]
+                    DisplayName = $values[1]
+                    Version     = $values[2]
+                    NewPackage  = $values[3] -eq 'True'
+                }
             }
         }
     }

--- a/source/suffix.ps1
+++ b/source/suffix.ps1
@@ -65,7 +65,7 @@ foreach ($typeToExport in  @($typesToExportWithNamespace + $typesToExportAsIs))
                 'Accelerator already exists.'
             ) -join ' - '
 
-            Write-Warning -Message $Message
+            Write-Debug -Message $Message
         }
         else
         {

--- a/tests/Unit/Private/Register-ChocolateyArgumentCompleter.tests.ps1
+++ b/tests/Unit/Private/Register-ChocolateyArgumentCompleter.tests.ps1
@@ -47,10 +47,18 @@ Describe Register-ChocolateyArgumentCompleter {
         }
 
         It 'Should register the expected command and parameter combinations' {
-            $script:registrations.Count | Should -Be 7
+            $script:registrations.Count | Should -Be 8
 
             @($script:registrations | Where-Object -FilterScript {
                 $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Update-ChocolateyPackage'
+            }).Count | Should -Be 1
+
+            @($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Optimize-ChocolateyPackage'
+            }).Count | Should -Be 1
+
+            @($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Name' -and $_.CommandName -contains 'Compare-ChocolateyPackage'
             }).Count | Should -Be 1
 
             @($script:registrations | Where-Object -FilterScript {
@@ -67,6 +75,14 @@ Describe Register-ChocolateyArgumentCompleter {
 
             @($script:registrations | Where-Object -FilterScript {
                 $_.ParameterName -eq 'Setting' -and $_.CommandName -contains 'Get-ChocolateySetting'
+            }).Count | Should -Be 1
+
+            @($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Source' -and $_.CommandName -contains 'Install-ChocolateyPackage'
+            }).Count | Should -Be 1
+
+            @($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Source' -and $_.CommandName -contains 'Publish-ChocolateyPackage'
             }).Count | Should -Be 1
         }
 
@@ -115,6 +131,30 @@ Describe Register-ChocolateyArgumentCompleter {
             $result | Should -Be 'feature-result'
             Should -Invoke New-ChocolateyCompletionResultForFeatureName -Times 1 -Exactly -ParameterFilter {
                 $WordToComplete -eq 'show'
+            }
+        }
+
+        It 'Should use the source completion helper for package operation commands' {
+            Mock New-ChocolateyCompletionResultForSourceName -MockWith { 'source-result' }
+
+            $registration = @($script:registrations | Where-Object -FilterScript {
+                $_.ParameterName -eq 'Source' -and $_.CommandName -contains 'Install-ChocolateyPackage'
+            }) | Select-Object -First 1
+
+            $result = InModuleScope -ScriptBlock {
+                param
+                (
+                    [Parameter()]
+                    [scriptblock]
+                    $ScriptBlock
+                )
+
+                & $ScriptBlock 'Install-ChocolateyPackage' 'Source' 'int' $null @{}
+            } -Parameters @{ ScriptBlock = $registration.ScriptBlock }
+
+            $result | Should -Be 'source-result'
+            Should -Invoke New-ChocolateyCompletionResultForSourceName -Times 1 -Exactly -ParameterFilter {
+                $WordToComplete -eq 'int'
             }
         }
     }

--- a/tests/Unit/Public/Convert-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Convert-ChocolateyPackage.tests.ps1
@@ -1,0 +1,115 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Convert-ChocolateyPackage {
+    Context 'When no Chocolatey license is installed' {
+        BeforeAll {
+            Mock Get-ChocolateyCommand -MockWith { 'choco' }
+            Mock Get-ChocolateyInstallPath -MockWith { 'C:\ProgramData\chocolatey' }
+            Mock Test-ChocolateyLicenseInstalled -MockWith { $false }
+        }
+
+        It 'Should throw a license error' {
+            {
+                Convert-ChocolateyPackage -Path 'sysinternals.nupkg' -ToFormat 'intune' -Confirm:$false
+            } | Should -Throw '*requires a Chocolatey for Business license file*'
+        }
+    }
+
+    Context 'When a Chocolatey license is installed' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'converted'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+            Mock Get-ChocolateyInstallPath -MockWith { 'C:\ProgramData\chocolatey' }
+            Mock Test-ChocolateyLicenseInstalled -MockWith { $true }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should not return a value' {
+            $result = Convert-ChocolateyPackage -Path 'sysinternals.nupkg' -ToFormat 'intune' -Confirm:$false
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should pass convert as the first choco argument' {
+            $null = Convert-ChocolateyPackage -Path 'sysinternals.nupkg' -ToFormat 'intune' -Confirm:$false
+
+            $script:capturedArguments[0] | Should -Be 'convert'
+        }
+
+        It 'Should pass the nupkg path as the second argument' {
+            $null = Convert-ChocolateyPackage -Path 'sysinternals.nupkg' -ToFormat 'intune' -Confirm:$false
+
+            $script:capturedArguments[1] | Should -Be 'sysinternals.nupkg'
+        }
+
+        It 'Should pass --to-format when converting by path' {
+            $null = Convert-ChocolateyPackage -Path 'sysinternals.nupkg' -ToFormat 'intune' -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--to-format="intune"'
+        }
+
+        It 'Should pass -y when confirmed' {
+            $null = Convert-ChocolateyPackage -Path 'sysinternals.nupkg' -ToFormat 'intune' -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '-y'
+        }
+
+        It 'Should pass --include-all when IncludeAll is specified' {
+            $null = Convert-ChocolateyPackage -IncludeAll -ToFormat 'intune' -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--include-all'
+        }
+
+        It 'Should not pass a path argument when IncludeAll is specified' {
+            $null = Convert-ChocolateyPackage -IncludeAll -ToFormat 'intune' -Confirm:$false
+
+            @($script:capturedArguments | Where-Object -FilterScript { $_ -like '*.nupkg' }).Count | Should -Be 0
+        }
+
+        It 'Should not execute when WhatIf is specified' {
+            $null = Convert-ChocolateyPackage -Path 'sysinternals.nupkg' -ToFormat 'intune' -WhatIf
+
+            $script:capturedArguments | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Public/Optimize-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Optimize-ChocolateyPackage.tests.ps1
@@ -1,0 +1,109 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Optimize-ChocolateyPackage {
+    Context 'When no Chocolatey license is installed' {
+        BeforeAll {
+            Mock Get-ChocolateyCommand -MockWith { 'choco' }
+            Mock Get-ChocolateyInstallPath -MockWith { 'C:\ProgramData\chocolatey' }
+            Mock Test-ChocolateyLicenseInstalled -MockWith { $false }
+        }
+
+        It 'Should throw a license error' {
+            {
+                Optimize-ChocolateyPackage -RunNonElevated -Confirm:$false
+            } | Should -Throw '*requires a Chocolatey Licensed Edition license file*'
+        }
+    }
+
+    Context 'When a Chocolatey license is installed' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'optimized'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+            Mock Get-ChocolateyInstallPath -MockWith { 'C:\ProgramData\chocolatey' }
+            Mock Test-ChocolateyLicenseInstalled -MockWith { $true }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should not return a value' {
+            $result = Optimize-ChocolateyPackage -RunNonElevated -Confirm:$false
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should pass optimize as the first choco argument' {
+            $null = Optimize-ChocolateyPackage -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments[0] | Should -Be 'optimize'
+        }
+
+        It 'Should pass -y when confirmed' {
+            $null = Optimize-ChocolateyPackage -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '-y'
+        }
+
+        It 'Should pass --id when Name is specified' {
+            $null = Optimize-ChocolateyPackage -Name 'googlechrome' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--id="googlechrome"'
+        }
+
+        It 'Should not pass --id when Name is not specified' {
+            $null = Optimize-ChocolateyPackage -RunNonElevated -Confirm:$false
+
+            @($script:capturedArguments | Where-Object -FilterScript { $_ -like '--id*' }).Count | Should -Be 0
+        }
+
+        It 'Should pass --reduce-nupkg-only when ReduceNupkgOnly is specified' {
+            $null = Optimize-ChocolateyPackage -ReduceNupkgOnly -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--reduce-nupkg-only'
+        }
+
+        It 'Should not execute when WhatIf is specified' {
+            $null = Optimize-ChocolateyPackage -RunNonElevated -WhatIf
+
+            $script:capturedArguments | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Public/Save-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Save-ChocolateyPackage.tests.ps1
@@ -56,6 +56,48 @@ Describe Save-ChocolateyPackage {
 
             $return | Should -BeNullOrEmpty
         }
+
+        It 'Should throw when choco output contains not downloaded' {
+            function global:Invoke-FakeChocoFail {
+                param (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                'sysinternals - not downloaded'
+                '1 packages not downloaded.'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChocoFail' }
+
+            {
+                Save-ChocolateyPackage -Name 'sysinternals'
+            } | Should -Throw '*not downloaded*'
+
+            Remove-Item -Path Function:\Invoke-FakeChocoFail -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should write choco output to the verbose stream' {
+            function global:Invoke-FakeChocoVerbose {
+                param (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                'Saving sysinternals to C:\packages'
+                'sysinternals - saved'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChocoVerbose' }
+
+            $verboseOutput = Save-ChocolateyPackage -Name 'sysinternals' -Verbose 4>&1
+
+            @($verboseOutput | Where-Object { $_ -match 'Saving sysinternals' }).Count | Should -Be 1
+
+            Remove-Item -Path Function:\Invoke-FakeChocoVerbose -ErrorAction 'SilentlyContinue'
+        }
     }
 
     Context 'When using licensed-only download parameters' {

--- a/tests/Unit/Public/Sync-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Sync-ChocolateyPackage.tests.ps1
@@ -1,0 +1,115 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Sync-ChocolateyPackage {
+    Context 'When no Chocolatey license is installed' {
+        BeforeAll {
+            Mock Get-ChocolateyCommand -MockWith { 'choco' }
+            Mock Get-ChocolateyInstallPath -MockWith { 'C:\ProgramData\chocolatey' }
+            Mock Test-ChocolateyLicenseInstalled -MockWith { $false }
+        }
+
+        It 'Should throw a license error' {
+            {
+                Sync-ChocolateyPackage -RunNonElevated -Confirm:$false
+            } | Should -Throw '*requires a Chocolatey for Business license file*'
+        }
+    }
+
+    Context 'When a Chocolatey license is installed' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'synced'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+            Mock Get-ChocolateyInstallPath -MockWith { 'C:\ProgramData\chocolatey' }
+            Mock Test-ChocolateyLicenseInstalled -MockWith { $true }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should not return a value' {
+            $result = Sync-ChocolateyPackage -RunNonElevated -Confirm:$false
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should pass sync as the first choco argument' {
+            $null = Sync-ChocolateyPackage -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments[0] | Should -Be 'sync'
+        }
+
+        It 'Should pass -y when confirmed' {
+            $null = Sync-ChocolateyPackage -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '-y'
+        }
+
+        It 'Should pass --id when Id is specified' {
+            $null = Sync-ChocolateyPackage -Id 'Putty' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--id="Putty"'
+        }
+
+        It 'Should not pass --id when Id is not specified' {
+            $null = Sync-ChocolateyPackage -RunNonElevated -Confirm:$false
+
+            @($script:capturedArguments | Where-Object -FilterScript { $_ -like '--id*' }).Count | Should -Be 0
+        }
+
+        It 'Should pass --package-id when PackageId is specified' {
+            $null = Sync-ChocolateyPackage -Id 'Putty' -PackageId 'putty.portable' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--package-id="putty.portable"'
+        }
+
+        It 'Should not pass --package-id when PackageId is not specified' {
+            $null = Sync-ChocolateyPackage -RunNonElevated -Confirm:$false
+
+            @($script:capturedArguments | Where-Object -FilterScript { $_ -like '--package-id*' }).Count | Should -Be 0
+        }
+
+        It 'Should not execute when WhatIf is specified' {
+            $null = Sync-ChocolateyPackage -RunNonElevated -WhatIf
+
+            $script:capturedArguments | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Public/Sync-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Sync-ChocolateyPackage.tests.ps1
@@ -48,7 +48,9 @@ Describe Sync-ChocolateyPackage {
                 )
 
                 $script:capturedArguments = $Arguments
-                'synced'
+                'Package Id|Display Name|Version|New Package'
+                'globalprotect|GlobalProtect|6.2.8|True'
+                'putty|Putty|0.76|False'
             }
 
             Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
@@ -64,10 +66,16 @@ Describe Sync-ChocolateyPackage {
             Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
         }
 
-        It 'Should not return a value' {
-            $result = Sync-ChocolateyPackage -RunNonElevated -Confirm:$false
+        It 'Should return parsed sync results as objects' {
+            $result = @(Sync-ChocolateyPackage -RunNonElevated -Confirm:$false)
 
-            $result | Should -BeNullOrEmpty
+            $result.Count | Should -Be 2
+            $result[0].PackageId   | Should -Be 'globalprotect'
+            $result[0].DisplayName | Should -Be 'GlobalProtect'
+            $result[0].Version     | Should -Be '6.2.8'
+            $result[0].NewPackage  | Should -BeTrue
+            $result[1].PackageId   | Should -Be 'putty'
+            $result[1].NewPackage  | Should -BeFalse
         }
 
         It 'Should pass sync as the first choco argument' {


### PR DESCRIPTION
- Optimize-ChocolateyPackage: wraps choco optimize (C4B licensed), supports
  optional -Name (--id), -ReduceNupkgOnly, RunNonElevated guard
- Sync-ChocolateyPackage: wraps choco sync (C4B licensed), supports -Id (--id),
  -PackageId (--package-id), -OutputDirectory, RunNonElevated guard
- Convert-ChocolateyPackage: wraps choco convert (C4B licensed), supports
  -Path or -IncludeAll param sets, -ToFormat (intune only)
- All three fail-fast with a license check in begin{} via
  Test-ChocolateyLicenseInstalled
- Full unit test coverage (8/9/9 tests respectively), all passing
- CHANGELOG.md Unreleased entry updated
