### PR TITLE
Add missing tests and update code coverage threshold to 30%

### DIFF
--- a/.github/instructions/public-functions.instructions.md
+++ b/.github/instructions/public-functions.instructions.md
@@ -40,6 +40,7 @@ applyTo: 'source/public/**/*.ps1'
 ```
 
 - User-visible behavior changes require an `Unreleased` changelog entry.
+- When adding a new public wrapper for a `choco` command, update the **Command coverage** table in `README.md`: move the row from `—` to the new function name, and remove the corresponding bullet from the "Not yet implemented" list.
 
 ## Argument completers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `Home.md` wiki landing page under `source\WikiSource`.
 - Added a `LicensedChocolatey.md` wiki page covering license install, removal,
   and the licensed-extension compatibility warning.
+- Added missing Pester tests for public and private Chocolatey wrapper functions, expanded the README command coverage and argument completer documentation, and increased the CI code coverage target from 8% to 30%.
 
 ### Fixed
 
@@ -127,7 +128,7 @@ for DSCv3 that combines Name and Version to uniquely identify package instances.
 - Invoking choco commands now always add `--no-progress` & `--limit-output`.
 - Limiting Get-Command choco to the first result as per [#69](https://github.com/chocolatey-community/Chocolatey/issues/69) on all calls.
 - Changed `ChocolateySoftware` to be class-based DSC Resource.
-- Changed `ChocolateyPackage` to be class-based DSC Resource.
+- Changed `ChocolateyPackage` to be a class-based DSC Resource.
 - Changed `ChocolateySource` to be a class-based DSC Resource.
 - Changed `ChocolateyFeature` to be a class-based DSC Resource.
 

--- a/README.md
+++ b/README.md
@@ -21,19 +21,65 @@ deployed to [PowerShell Gallery](https://www.powershellgallery.com/).
 Periodically a release version tag will be pushed which will deploy a
 full release to [PowerShell Gallery](https://www.powershellgallery.com/).
 
+## Command coverage
+
+The table below tracks which `choco` CLI commands have a PowerShell wrapper.
+Update this table whenever a new public function is added or removed.
+
+| `choco` command | PowerShell wrapper | Edition |
+|---|---|---|
+| `list` / `search` | `Get-ChocolateyPackage` | OSS |
+| `find` | `Find-ChocolateyPackage` | OSS |
+| `info` | — | OSS |
+| `install` | `Install-ChocolateyPackage` | OSS |
+| `upgrade` | `Update-ChocolateyPackage` | OSS |
+| `uninstall` | `Uninstall-ChocolateyPackage` | OSS |
+| `outdated` | — | OSS |
+| `pin add/remove/list` | `Add-`, `Remove-`, `Get-ChocolateyPin` | OSS |
+| `pack` | — | OSS |
+| `push` | `Publish-ChocolateyPackage` | OSS |
+| `new` | — | OSS |
+| `export` | — | OSS |
+| `download` | `Save-ChocolateyPackage` | Licensed |
+| `source add/remove/list/enable/disable` | `Register-`, `Unregister-`, `Get-`, `Enable-`, `Disable-ChocolateySource` | OSS |
+| `config get/set/list` | `Get-`, `Set-ChocolateySetting` | OSS |
+| `config unset` | — | OSS |
+| `feature enable/disable/list` | `Enable-`, `Disable-`, `Get-ChocolateyFeature` | OSS |
+| `apikey add/remove/list` | — | OSS |
+| `template list/info` | — | OSS |
+| `cache` | — | OSS |
+| `sync` | `Sync-ChocolateyPackage` | C4B |
+| `optimize` | `Optimize-ChocolateyPackage` | Licensed |
+| `convert` | `Convert-ChocolateyPackage` | C4B |
+
+**Not yet implemented (open for contribution):**
+
+- `Get-ChocolateyPackageInfo` — wraps `choco info`; returns detailed metadata for a package from a source
+- `Get-ChocolateyOutdatedPackage` — wraps `choco outdated`; lists installed packages that have newer versions available
+- `New-ChocolateyPackage` — wraps `choco pack`; creates a `.nupkg` from a `.nuspec`
+- `New-ChocolateyPackageScaffold` — wraps `choco new`; scaffolds a new package directory from a template
+- `Export-ChocolateyPackage` — wraps `choco export`; exports installed packages to a `packages.config`
+- `Set-ChocolateyApiKey` / `Get-ChocolateyApiKey` / `Remove-ChocolateyApiKey` — wraps `choco apikey`
+- `Remove-ChocolateySetting` — wraps `choco config unset`
+- `Get-ChocolateyPackageTemplate` / `Install-ChocolateyPackageTemplate` / `Uninstall-ChocolateyPackageTemplate` — wraps `choco template`
+- `Clear-ChocolateyCache` — wraps `choco cache`
+
 ## PowerShell argument completers
 
 Importing the module registers PowerShell argument completers for common
 Chocolatey wrapper commands.
 
-- Package name completion for `Get-ChocolateyPackage`,
-  `Uninstall-ChocolateyPackage`, `Update-ChocolateyPackage`, and
-  `Add-ChocolateyPin`
+- Package name completion (installed packages) for `Get-ChocolateyPackage`,
+  `Uninstall-ChocolateyPackage`, `Update-ChocolateyPackage`,
+  `Compare-ChocolateyPackage`, `Optimize-ChocolateyPackage`, and `Add-ChocolateyPin`
 - Pin name completion for `Get-ChocolateyPin`, `Remove-ChocolateyPin`, and
   `Test-ChocolateyPin`
 - Source name completion for `Get-ChocolateySource`, `Test-ChocolateySource`,
-  `Enable-ChocolateySource`, `Disable-ChocolateySource`, and
-  `Unregister-ChocolateySource`
+  `Enable-ChocolateySource`, `Disable-ChocolateySource`,
+  `Unregister-ChocolateySource`, `Install-ChocolateyPackage`,
+  `Update-ChocolateyPackage`, `Uninstall-ChocolateyPackage`,
+  `Save-ChocolateyPackage`, `Find-ChocolateyPackage`,
+  `Compare-ChocolateyPackage`, and `Publish-ChocolateyPackage`
 - Feature name completion for `Get-ChocolateyFeature`,
   `Test-ChocolateyFeature`, `Enable-ChocolateyFeature`, and
   `Disable-ChocolateyFeature`

--- a/build.yaml
+++ b/build.yaml
@@ -124,7 +124,7 @@ Pester:
       StackTraceVerbosity: Full
       CIFormat: Auto
     CodeCoverage:
-      CoveragePercentTarget: 21
+      CoveragePercentTarget: 30
       OutputPath: JaCoCo_Merge.xml
       OutputEncoding: ascii
       UseBreakpoints: false

--- a/build.yaml
+++ b/build.yaml
@@ -124,7 +124,7 @@ Pester:
       StackTraceVerbosity: Full
       CIFormat: Auto
     CodeCoverage:
-      CoveragePercentTarget: 8
+      CoveragePercentTarget: 21
       OutputPath: JaCoCo_Merge.xml
       OutputEncoding: ascii
       UseBreakpoints: false

--- a/tests/Unit/Private/Assert-ChocolateyIsElevated.tests.ps1
+++ b/tests/Unit/Private/Assert-ChocolateyIsElevated.tests.ps1
@@ -1,1 +1,44 @@
-# TODO
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Assert-ChocolateyIsElevated {
+    BeforeAll {
+        $script:isElevated = [Security.Principal.WindowsPrincipal]::New([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+
+    It 'Should write a verbose message when the process is elevated' -Skip:(-not $script:isElevated) {
+        $verboseOutput = InModuleScope -ScriptBlock {
+            Assert-ChocolateyIsElevated -Verbose 4>&1
+        }
+
+        @($verboseOutput | Where-Object -FilterScript { $_.Message -eq 'This process is running elevated.' }).Count | Should -Be 1
+    }
+
+    It 'Should throw when the process is not elevated' -Skip:$script:isElevated {
+        {
+            InModuleScope -ScriptBlock {
+                Assert-ChocolateyIsElevated
+            }
+        } | Should -Throw 'This command must be ran elevated.'
+    }
+}

--- a/tests/Unit/Public/Get-ChocolateyFeature.tests.ps1
+++ b/tests/Unit/Public/Get-ChocolateyFeature.tests.ps1
@@ -1,0 +1,56 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Get-ChocolateyFeature {
+    BeforeAll {
+        Mock Get-ChocolateyCommand -MockWith { [PSCustomObject]@{ Path = $script:fakeChocoPath } }
+    }
+
+    BeforeEach {
+        $script:installRoot = Join-Path -Path $TestDrive -ChildPath 'choco'
+        $script:fakeChocoPath = Join-Path -Path $script:installRoot -ChildPath 'bin\choco.exe'
+        $script:configPath = Join-Path -Path $script:installRoot -ChildPath 'config\chocolatey.config'
+
+        $null = New-Item -Path (Split-Path -Path $script:fakeChocoPath -Parent) -ItemType Directory -Force
+        $null = New-Item -Path (Split-Path -Path $script:configPath -Parent) -ItemType Directory -Force
+        $null = Set-Content -Path $script:fakeChocoPath -Value ''
+        $null = Set-Content -Path $script:configPath -Value '<chocolatey><features><feature name="checksumFiles" enabled="true" /><feature name="showNonElevatedWarnings" enabled="false" /></features></chocolatey>'
+    }
+
+    It 'Should return all features from the Chocolatey configuration' {
+        $result = @(Get-ChocolateyFeature)
+
+        $result.Count | Should -Be 2
+        $result[0].PSTypeNames[0] | Should -Be 'Chocolatey.Feature'
+        $result[0].name | Should -Be 'checksumFiles'
+        $result[0].enabled | Should -Be 'true'
+    }
+
+    It 'Should return the requested feature by name' {
+        $result = @(Get-ChocolateyFeature -Name 'shownonelevatedwarnings')
+
+        $result.Count | Should -Be 1
+        $result[0].name | Should -Be 'showNonElevatedWarnings'
+        $result[0].enabled | Should -Be 'false'
+    }
+}

--- a/tests/Unit/Public/Get-ChocolateyPin.tests.ps1
+++ b/tests/Unit/Public/Get-ChocolateyPin.tests.ps1
@@ -1,0 +1,93 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Get-ChocolateyPin {
+    Context 'Default' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                $script:chocoOutput
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+            Mock Get-ChocolateyPackage -MockWith {
+                [PSCustomObject]@{
+                    Name    = $Name
+                    Version = '2.47.0'
+                }
+            }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+            $script:chocoOutput = @(
+                'git|2.47.0'
+                '7zip|24.09'
+            )
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should return parsed pin results as objects' {
+            $result = @(Get-ChocolateyPin)
+
+            $result.Count | Should -Be 2
+            $result[0].Name | Should -Be 'git'
+            $result[0].Version | Should -Be '2.47.0'
+            $result[1].Name | Should -Be '7zip'
+        }
+
+        It 'Should pass pin list as the choco subcommand' {
+            $null = @(Get-ChocolateyPin)
+
+            $script:capturedArguments[0] | Should -Be 'pin'
+            $script:capturedArguments[1] | Should -Be 'list'
+            $script:capturedArguments | Should -Contain '--limit-output'
+        }
+
+        It 'Should filter the results when Name is specified' {
+            $result = @(Get-ChocolateyPin -Name 'git')
+
+            $result.Count | Should -Be 1
+            $result[0].Name | Should -Be 'git'
+        }
+
+        It 'Should throw when the requested package cannot be found' {
+            Mock Get-ChocolateyPackage -MockWith { $null } -ParameterFilter { $Name -eq 'missing' -and $Exact }
+
+            {
+                Get-ChocolateyPin -Name 'missing'
+            } | Should -Throw 'Chocolatey Package missing cannot be found.'
+        }
+    }
+}

--- a/tests/Unit/Public/Get-ChocolateySetting.tests.ps1
+++ b/tests/Unit/Public/Get-ChocolateySetting.tests.ps1
@@ -1,0 +1,56 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Get-ChocolateySetting {
+    BeforeAll {
+        Mock Get-ChocolateyCommand -MockWith { [PSCustomObject]@{ Path = $script:fakeChocoPath } }
+    }
+
+    BeforeEach {
+        $script:installRoot = Join-Path -Path $TestDrive -ChildPath 'choco'
+        $script:fakeChocoPath = Join-Path -Path $script:installRoot -ChildPath 'bin\choco.exe'
+        $script:configPath = Join-Path -Path $script:installRoot -ChildPath 'config\chocolatey.config'
+
+        $null = New-Item -Path (Split-Path -Path $script:fakeChocoPath -Parent) -ItemType Directory -Force
+        $null = New-Item -Path (Split-Path -Path $script:configPath -Parent) -ItemType Directory -Force
+        $null = Set-Content -Path $script:fakeChocoPath -Value ''
+        $null = Set-Content -Path $script:configPath -Value '<chocolatey><config><add key="cacheLocation" value="C:\cache" /><add key="commandExecutionTimeoutSeconds" value="2700" /></config></chocolatey>'
+    }
+
+    It 'Should return all settings from the Chocolatey configuration' {
+        $result = @(Get-ChocolateySetting)
+
+        $result.Count | Should -Be 2
+        $result[0].PSTypeNames[0] | Should -Be 'Chocolatey.Setting'
+        $result[0].key | Should -Be 'cacheLocation'
+        $result[0].value | Should -Be 'C:\cache'
+    }
+
+    It 'Should return the requested setting by name' {
+        $result = @(Get-ChocolateySetting -Name 'cacheLocation')
+
+        $result.Count | Should -Be 1
+        $result[0].key | Should -Be 'cacheLocation'
+        $result[0].value | Should -Be 'C:\cache'
+    }
+}

--- a/tests/Unit/Public/Get-ChocolateySource.tests.ps1
+++ b/tests/Unit/Public/Get-ChocolateySource.tests.ps1
@@ -1,0 +1,60 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Get-ChocolateySource {
+    BeforeAll {
+        Mock Get-ChocolateyCommand -MockWith { [PSCustomObject]@{ Path = $script:fakeChocoPath } }
+    }
+
+    BeforeEach {
+        $script:installRoot = Join-Path -Path $TestDrive -ChildPath 'choco'
+        $script:fakeChocoPath = Join-Path -Path $script:installRoot -ChildPath 'bin\choco.exe'
+        $script:configPath = Join-Path -Path $script:installRoot -ChildPath 'config\chocolatey.config'
+
+        $null = New-Item -Path (Split-Path -Path $script:fakeChocoPath -Parent) -ItemType Directory -Force
+        $null = New-Item -Path (Split-Path -Path $script:configPath -Parent) -ItemType Directory -Force
+        $null = Set-Content -Path $script:fakeChocoPath -Value ''
+        $null = Set-Content -Path $script:configPath -Value '<chocolatey><sources><source id="Chocolatey" value="https://community.chocolatey.org/api/v2/" disabled="false" bypassProxy="true" selfService="false" priority="0" user="" password="" /><source id="Internal" value="https://proget/nuget/choco" disabled="true" bypassProxy="false" selfService="true" priority="10" user="svc" password="secret" /></sources></chocolatey>'
+    }
+
+    It 'Should return all configured sources' {
+        $result = @(Get-ChocolateySource)
+
+        $result.Count | Should -Be 2
+        $result[0].PSTypeNames[0] | Should -Be 'Chocolatey.Source'
+        $result[0].Name | Should -Be 'Chocolatey'
+        $result[0].Source | Should -Be 'https://community.chocolatey.org/api/v2/'
+        $result[0].disabled | Should -BeFalse
+        $result[0].bypassProxy | Should -BeTrue
+    }
+
+    It 'Should return the requested source by name' {
+        $result = @(Get-ChocolateySource -Name 'internal')
+
+        $result.Count | Should -Be 1
+        $result[0].Name | Should -Be 'Internal'
+        $result[0].disabled | Should -BeTrue
+        $result[0].selfService | Should -BeTrue
+        $result[0].priority | Should -Be 10
+    }
+}

--- a/tests/Unit/Public/Install-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Install-ChocolateyPackage.tests.ps1
@@ -1,0 +1,90 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Install-ChocolateyPackage {
+    Context 'Default' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'installed'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+            Mock Remove-ChocolateyPackageCache -MockWith {}
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should call Remove-ChocolateyPackageCache before invoking choco' {
+            $null = Install-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            { Assert-MockCalled Remove-ChocolateyPackageCache } | Should -Not -Throw
+        }
+
+        It 'Should not return a value' {
+            $result = Install-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should pass install as the first choco argument' {
+            $null = Install-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments[0] | Should -Be 'install'
+            $script:capturedArguments[1] | Should -Be 'git'
+        }
+
+        It 'Should pass -y when confirmed' {
+            $null = Install-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '-y'
+        }
+
+        It 'Should pass version and source arguments when specified' {
+            $null = Install-ChocolateyPackage -Name 'git' -Version '2.47.0' -Source 'https://community.chocolatey.org/api/v2/' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--version="2.47.0"'
+            $script:capturedArguments | Should -Contain '-s"https://community.chocolatey.org/api/v2/"'
+        }
+
+        It 'Should not execute when WhatIf is specified' {
+            $null = Install-ChocolateyPackage -Name 'git' -RunNonElevated -WhatIf
+
+            $script:capturedArguments | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Public/Register-ChocolateySource.tests.ps1
+++ b/tests/Unit/Public/Register-ChocolateySource.tests.ps1
@@ -1,0 +1,91 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Register-ChocolateySource {
+    Context 'Default' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                $script:capturedInvocations.Add(@($Arguments))
+                'source updated'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+            $script:capturedInvocations = [System.Collections.Generic.List[object[]]]::new()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should not return a value' {
+            $result = Register-ChocolateySource -Name 'Internal' -Source 'https://proget/nuget/choco' -RunNonElevated -Confirm:$false
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should pass source add as the choco subcommand' {
+            $null = Register-ChocolateySource -Name 'Internal' -Source 'https://proget/nuget/choco' -RunNonElevated -Confirm:$false
+
+            $script:capturedInvocations[0][0] | Should -Be 'source'
+            $script:capturedInvocations[0][1] | Should -Be 'add'
+        }
+
+        It 'Should pass key source arguments when specified' {
+            $null = Register-ChocolateySource -Name 'Internal' -Source 'https://proget/nuget/choco' -Priority 10 -BypassProxy -SelfService -RunNonElevated -Confirm:$false
+
+            $script:capturedInvocations[0] | Should -Contain '--name="Internal"'
+            $script:capturedInvocations[0] | Should -Contain '-s"https://proget/nuget/choco"'
+            $script:capturedInvocations[0] | Should -Contain '--priority=10'
+            $script:capturedInvocations[0] | Should -Contain '--bypass-proxy'
+            $script:capturedInvocations[0] | Should -Contain '--allow-self-service'
+        }
+
+        It 'Should disable the source after registration when Disabled is specified' {
+            $null = Register-ChocolateySource -Name 'Internal' -Source 'https://proget/nuget/choco' -Disabled -RunNonElevated -Confirm:$false
+
+            $script:capturedInvocations.Count | Should -Be 2
+            $script:capturedInvocations[1][0] | Should -Be 'source'
+            $script:capturedInvocations[1][1] | Should -Be 'disable'
+            $script:capturedInvocations[1] | Should -Contain '-n="Internal"'
+        }
+
+        It 'Should not execute when WhatIf is specified' {
+            $null = Register-ChocolateySource -Name 'Internal' -Source 'https://proget/nuget/choco' -RunNonElevated -WhatIf
+
+            $script:capturedInvocations.Count | Should -Be 0
+        }
+    }
+}

--- a/tests/Unit/Public/Set-ChocolateySetting.tests.ps1
+++ b/tests/Unit/Public/Set-ChocolateySetting.tests.ps1
@@ -1,0 +1,85 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Set-ChocolateySetting {
+    Context 'Default' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'setting updated'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should not return a value' {
+            $result = Set-ChocolateySetting -Name 'cacheLocation' -Value 'C:\cache' -RunNonElevated -Confirm:$false
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should use config set when Value is specified' {
+            $null = Set-ChocolateySetting -Name 'cacheLocation' -Value 'C:\cache' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments[0] | Should -Be 'config'
+            $script:capturedArguments[1] | Should -Be 'set'
+        }
+
+        It 'Should pass the name and expanded value arguments when setting a value' {
+            $null = Set-ChocolateySetting -Name 'cacheLocation' -Value '$env:SystemDrive\ChocolateyCache\' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--name="cacheLocation"'
+            $script:capturedArguments | Should -Contain ('--value="{0}\ChocolateyCache"' -f $env:SystemDrive)
+        }
+
+        It 'Should use config unset and omit --value when Unset is specified' {
+            $null = Set-ChocolateySetting -Name 'cacheLocation' -Unset -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments[0] | Should -Be 'config'
+            $script:capturedArguments[1] | Should -Be 'unset'
+            @($script:capturedArguments | Where-Object -FilterScript { $_ -like '--value=*' }).Count | Should -Be 0
+        }
+
+        It 'Should not execute when WhatIf is specified' {
+            $null = Set-ChocolateySetting -Name 'cacheLocation' -Value 'C:\cache' -RunNonElevated -WhatIf
+
+            $script:capturedArguments | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Public/Test-ChocolateyFeature.tests.ps1
+++ b/tests/Unit/Public/Test-ChocolateyFeature.tests.ps1
@@ -1,0 +1,67 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Test-ChocolateyFeature {
+    BeforeAll {
+        Mock Get-ChocolateyCommand -MockWith {}
+    }
+
+    It 'Should return false when the feature cannot be found' {
+        Mock Get-ChocolateyFeature -MockWith { $null } -ParameterFilter { $Name -eq 'checksumFiles' }
+
+        Test-ChocolateyFeature -Name 'checksumFiles' | Should -BeFalse
+    }
+
+    It 'Should return true when the feature is enabled as expected' {
+        Mock Get-ChocolateyFeature -MockWith {
+            [PSCustomObject]@{
+                Name    = 'checksumFiles'
+                Enabled = $true
+            }
+        } -ParameterFilter { $Name -eq 'checksumFiles' }
+
+        Test-ChocolateyFeature -Name 'checksumFiles' | Should -BeTrue
+    }
+
+    It 'Should return true when the feature is disabled as expected' {
+        Mock Get-ChocolateyFeature -MockWith {
+            [PSCustomObject]@{
+                Name    = 'checksumFiles'
+                Enabled = $false
+            }
+        } -ParameterFilter { $Name -eq 'checksumFiles' }
+
+        Test-ChocolateyFeature -Name 'checksumFiles' -Disabled | Should -BeTrue
+    }
+
+    It 'Should return false when the feature state does not match' {
+        Mock Get-ChocolateyFeature -MockWith {
+            [PSCustomObject]@{
+                Name    = 'checksumFiles'
+                Enabled = $false
+            }
+        } -ParameterFilter { $Name -eq 'checksumFiles' }
+
+        Test-ChocolateyFeature -Name 'checksumFiles' | Should -BeFalse
+    }
+}

--- a/tests/Unit/Public/Test-ChocolateyInstall.tests.ps1
+++ b/tests/Unit/Public/Test-ChocolateyInstall.tests.ps1
@@ -1,0 +1,73 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Test-ChocolateyInstall {
+    BeforeAll {
+        Mock Repair-ProcessEnvPath -MockWith {}
+    }
+
+    It 'Should return true when choco.exe is available on PATH' {
+        Mock Get-Command -MockWith {
+            param ($Name)
+
+            if ($Name -eq 'choco.exe')
+            {
+                [PSCustomObject]@{
+                    Path    = 'C:\ProgramData\chocolatey\bin\choco.exe'
+                    Version = '2.4.3'
+                }
+            }
+        }
+
+        Test-ChocolateyInstall | Should -BeTrue
+        { Assert-MockCalled Repair-ProcessEnvPath } | Should -Not -Throw
+    }
+
+    It 'Should return true when choco.exe is found under the specified install directory' {
+        $installDir = Join-Path -Path $TestDrive -ChildPath 'Chocolatey'
+        $chocoPath = Join-Path -Path $installDir -ChildPath 'choco.exe'
+
+        $null = New-Item -Path $installDir -ItemType Directory -Force
+        $null = Set-Content -Path $chocoPath -Value ''
+
+        Mock Get-Command -MockWith {
+            param ($Name)
+
+            if ($Name -eq $chocoPath -or $Name -eq 'choco.exe')
+            {
+                [PSCustomObject]@{
+                    Path    = $chocoPath
+                    Version = '2.4.3'
+                }
+            }
+        }
+
+        Test-ChocolateyInstall -InstallDir $installDir | Should -BeTrue
+    }
+
+    It 'Should return false when choco.exe cannot be found' {
+        Mock Get-Command -MockWith { $null }
+
+        Test-ChocolateyInstall | Should -BeFalse
+    }
+}

--- a/tests/Unit/Public/Test-ChocolateyPackageIsInstalled.tests.ps1
+++ b/tests/Unit/Public/Test-ChocolateyPackageIsInstalled.tests.ps1
@@ -1,0 +1,80 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Get-ChocolateyPackage {
+    Context 'When checking whether a package is installed with Exact' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                $script:chocoOutput
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+            $script:chocoOutput = @('chocolatey|2.4.3')
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should pass list as the first choco argument' {
+            $null = @(Get-ChocolateyPackage -Name 'chocolatey' -Exact)
+
+            $script:capturedArguments[0] | Should -Be 'list'
+        }
+
+        It 'Should pass --exact when checking a specific package' {
+            $null = @(Get-ChocolateyPackage -Name 'chocolatey' -Exact)
+
+            $script:capturedArguments | Should -Contain '--exact'
+        }
+
+        It 'Should return the installed package entry when the package is present' {
+            $result = @(Get-ChocolateyPackage -Name 'chocolatey' -Exact)
+
+            $result.Count | Should -Be 1
+            $result[0].Name | Should -Be 'chocolatey'
+            $result[0].Version | Should -Be '2.4.3'
+        }
+
+        It 'Should return no package when the exact package is not installed' {
+            $script:chocoOutput = @()
+
+            $result = Get-ChocolateyPackage -Name 'chocolatey' -Exact
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Public/Test-ChocolateyPin.tests.ps1
+++ b/tests/Unit/Public/Test-ChocolateyPin.tests.ps1
@@ -1,0 +1,56 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Test-ChocolateyPin {
+    BeforeAll {
+        Mock Get-ChocolateyCommand -MockWith {}
+    }
+
+    It 'Should return false when the package pin cannot be found' {
+        Mock Get-ChocolateyPin -MockWith { $null } -ParameterFilter { $Name -eq 'git' }
+
+        Test-ChocolateyPin -Name 'git' -Version '2.47.0' | Should -BeFalse
+    }
+
+    It 'Should return true when the pin version matches' {
+        Mock Get-ChocolateyPin -MockWith {
+            [PSCustomObject]@{
+                Name    = 'git'
+                Version = '2.47.0'
+            }
+        } -ParameterFilter { $Name -eq 'git' }
+
+        Test-ChocolateyPin -Name 'git' -Version '2.47.0' | Should -BeTrue
+    }
+
+    It 'Should return false when the pin version does not match' {
+        Mock Get-ChocolateyPin -MockWith {
+            [PSCustomObject]@{
+                Name    = 'git'
+                Version = '2.46.0'
+            }
+        } -ParameterFilter { $Name -eq 'git' }
+
+        Test-ChocolateyPin -Name 'git' -Version '2.47.0' | Should -BeFalse
+    }
+}

--- a/tests/Unit/Public/Test-ChocolateySetting.tests.ps1
+++ b/tests/Unit/Public/Test-ChocolateySetting.tests.ps1
@@ -1,0 +1,67 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Test-ChocolateySetting {
+    BeforeAll {
+        Mock Get-ChocolateyCommand -MockWith {}
+    }
+
+    It 'Should return false when the setting cannot be found' {
+        Mock Get-ChocolateySetting -MockWith { $null } -ParameterFilter { $Name -eq 'cacheLocation' }
+
+        Test-ChocolateySetting -Name 'cacheLocation' -Value 'C:\cache' | Should -BeFalse
+    }
+
+    It 'Should return true when the setting value matches' {
+        Mock Get-ChocolateySetting -MockWith {
+            [PSCustomObject]@{
+                Name  = 'cacheLocation'
+                Value = ('{0}\ChocolateyCache' -f $env:SystemDrive)
+            }
+        } -ParameterFilter { $Name -eq 'cacheLocation' }
+
+        Test-ChocolateySetting -Name 'cacheLocation' -Value '$env:SystemDrive\ChocolateyCache\' | Should -BeTrue
+    }
+
+    It 'Should return true when Unset is specified and the value is empty' {
+        Mock Get-ChocolateySetting -MockWith {
+            [PSCustomObject]@{
+                Name  = 'cacheLocation'
+                Value = ''
+            }
+        } -ParameterFilter { $Name -eq 'cacheLocation' }
+
+        Test-ChocolateySetting -Name 'cacheLocation' -Unset | Should -BeTrue
+    }
+
+    It 'Should return false when the setting value does not match' {
+        Mock Get-ChocolateySetting -MockWith {
+            [PSCustomObject]@{
+                Name  = 'cacheLocation'
+                Value = 'C:\different'
+            }
+        } -ParameterFilter { $Name -eq 'cacheLocation' }
+
+        Test-ChocolateySetting -Name 'cacheLocation' -Value 'C:\cache' | Should -BeFalse
+    }
+}

--- a/tests/Unit/Public/Test-ChocolateySource.tests.ps1
+++ b/tests/Unit/Public/Test-ChocolateySource.tests.ps1
@@ -1,0 +1,74 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Test-ChocolateySource {
+    BeforeAll {
+        Mock Get-ChocolateyCommand -MockWith {}
+    }
+
+    It 'Should return false when the source cannot be found' {
+        Mock Get-ChocolateySource -MockWith { $null } -ParameterFilter { $Name -eq 'Internal' }
+
+        Test-ChocolateySource -Name 'Internal' | Should -BeFalse
+    }
+
+    It 'Should return no differences when the source matches the provided properties' {
+        Mock Get-ChocolateySource -MockWith {
+            [PSCustomObject]@{
+                Name        = 'Internal'
+                Source      = 'https://proget/nuget/choco'
+                disabled    = $false
+                bypassProxy = $true
+                selfService = $false
+                priority    = 10
+                username    = ''
+                password    = ''
+            }
+        } -ParameterFilter { $Name -eq 'Internal' }
+
+        $result = Test-ChocolateySource -Name 'Internal' -Source 'https://proget/nuget/choco' -BypassProxy -Priority 10
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'Should return differences when the source does not match the provided properties' {
+        Mock Get-ChocolateySource -MockWith {
+            [PSCustomObject]@{
+                Name        = 'Internal'
+                Source      = 'https://proget/nuget/choco'
+                disabled    = $false
+                bypassProxy = $true
+                selfService = $false
+                priority    = 5
+                username    = ''
+                password    = ''
+            }
+        } -ParameterFilter { $Name -eq 'Internal' }
+
+        $result = @(Test-ChocolateySource -Name 'Internal' -Source 'https://proget/nuget/choco' -BypassProxy -Priority 10)
+
+        $result.Count | Should -Be 2
+        @($result | Where-Object -FilterScript { $_.SideIndicator -eq '=>' }).Count | Should -Be 1
+        @($result | Where-Object -FilterScript { $_.SideIndicator -eq '<=' }).Count | Should -Be 1
+    }
+}

--- a/tests/Unit/Public/Uninstall-Chocolatey.tests.ps1
+++ b/tests/Unit/Public/Uninstall-Chocolatey.tests.ps1
@@ -1,0 +1,41 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Uninstall-Chocolatey {
+    It 'Should warn and return nothing when the install directory does not contain choco.exe' {
+        $installDir = Join-Path -Path $TestDrive -ChildPath 'Chocolatey'
+        $null = New-Item -Path $installDir -ItemType Directory -Force
+
+        $warningOutput = Uninstall-Chocolatey -InstallDir $installDir -RunNonElevated 3>&1
+
+        @($warningOutput | Where-Object -FilterScript { $_.Message -eq 'Chocolatey Installation Folder Not found.' }).Count | Should -Be 1
+    }
+
+    It 'Should warn and return nothing when no install directory or choco command can be found' {
+        Mock Get-ChocolateyCommand -MockWith { $null }
+
+        $warningOutput = Uninstall-Chocolatey -InstallDir '' -RunNonElevated 3>&1
+
+        @($warningOutput | Where-Object -FilterScript { $_.Message -eq 'Could not find Chocolatey Software Install Folder.' }).Count | Should -Be 1
+    }
+}

--- a/tests/Unit/Public/Uninstall-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Uninstall-ChocolateyPackage.tests.ps1
@@ -1,0 +1,90 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Uninstall-ChocolateyPackage {
+    Context 'Default' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'uninstalled'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+            Mock Remove-ChocolateyPackageCache -MockWith {}
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should call Remove-ChocolateyPackageCache before invoking choco' {
+            $null = Uninstall-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            { Assert-MockCalled Remove-ChocolateyPackageCache } | Should -Not -Throw
+        }
+
+        It 'Should not return a value' {
+            $result = Uninstall-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should pass uninstall as the first choco argument' {
+            $null = Uninstall-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments[0] | Should -Be 'uninstall'
+            $script:capturedArguments[1] | Should -Be 'git'
+        }
+
+        It 'Should pass -y when confirmed' {
+            $null = Uninstall-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '-y'
+        }
+
+        It 'Should pass version and source arguments when specified' {
+            $null = Uninstall-ChocolateyPackage -Name 'git' -Version '2.47.0' -Source 'https://community.chocolatey.org/api/v2/' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--version="2.47.0"'
+            $script:capturedArguments | Should -Contain '-s"https://community.chocolatey.org/api/v2/"'
+        }
+
+        It 'Should not execute when WhatIf is specified' {
+            $null = Uninstall-ChocolateyPackage -Name 'git' -RunNonElevated -WhatIf
+
+            $script:capturedArguments | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Public/Unregister-ChocolateySource.tests.ps1
+++ b/tests/Unit/Public/Unregister-ChocolateySource.tests.ps1
@@ -1,0 +1,89 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Unregister-ChocolateySource {
+    Context 'Default' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'source removed'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+            Mock Get-ChocolateySource -MockWith {
+                [PSCustomObject]@{
+                    Name = 'Internal'
+                }
+            }
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should call Get-ChocolateySource before unregistering the source' {
+            $null = Unregister-ChocolateySource -Name 'Internal' -RunNonElevated
+
+            { Assert-MockCalled Get-ChocolateySource } | Should -Not -Throw
+        }
+
+        It 'Should not return a value' {
+            $result = Unregister-ChocolateySource -Name 'Internal' -RunNonElevated
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should pass source remove as the choco subcommand' {
+            $null = Unregister-ChocolateySource -Name 'Internal' -RunNonElevated
+
+            $script:capturedArguments[0] | Should -Be 'source'
+            $script:capturedArguments[1] | Should -Be 'remove'
+        }
+
+        It 'Should pass the source name when specified' {
+            $null = Unregister-ChocolateySource -Name 'Internal' -RunNonElevated
+
+            $script:capturedArguments | Should -Contain '--name="Internal"'
+        }
+
+        It 'Should throw when the source cannot be found' {
+            Mock Get-ChocolateySource -MockWith { $null } -ParameterFilter { $Name -eq 'Missing' }
+
+            {
+                Unregister-ChocolateySource -Name 'Missing' -RunNonElevated
+            } | Should -Throw 'Chocolatey Source Missing cannot be found. You can Register it using Register-ChocolateySource.'
+        }
+    }
+}

--- a/tests/Unit/Public/Update-ChocolateyPackage.tests.ps1
+++ b/tests/Unit/Public/Update-ChocolateyPackage.tests.ps1
@@ -1,0 +1,90 @@
+BeforeAll {
+    $script:moduleName = 'Chocolatey'
+    $script:repoRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..\..\..')).Path
+    $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'SilentlyContinue' |
+        Sort-Object -Property FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+
+    if (-not $script:builtManifest)
+    {
+        & (Join-Path -Path $script:repoRoot -ChildPath 'build.ps1') -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+
+        $script:builtManifest = Get-ChildItem -Path (Join-Path -Path $script:repoRoot -ChildPath 'output\module\chocolatey') -Filter 'chocolatey.psd1' -Recurse -ErrorAction 'Stop' |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    Import-Module -Name $script:builtManifest -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+Describe Update-ChocolateyPackage {
+    Context 'Default' {
+        BeforeAll {
+            function global:Invoke-FakeChoco
+            {
+                param
+                (
+                    [Parameter(ValueFromRemainingArguments = $true)]
+                    [object[]]
+                    $Arguments
+                )
+
+                $script:capturedArguments = $Arguments
+                'updated'
+            }
+
+            Mock Get-ChocolateyCommand -MockWith { 'Invoke-FakeChoco' }
+            Mock Remove-ChocolateyPackageCache -MockWith {}
+        }
+
+        BeforeEach {
+            $script:capturedArguments = @()
+        }
+
+        AfterAll {
+            Remove-Item -Path Function:\Invoke-FakeChoco -ErrorAction 'SilentlyContinue'
+        }
+
+        It 'Should call Remove-ChocolateyPackageCache before invoking choco' {
+            $null = Update-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            { Assert-MockCalled Remove-ChocolateyPackageCache } | Should -Not -Throw
+        }
+
+        It 'Should not return a value' {
+            $result = Update-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should pass upgrade as the first choco argument' {
+            $null = Update-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments[0] | Should -Be 'upgrade'
+            $script:capturedArguments[1] | Should -Be 'git'
+        }
+
+        It 'Should pass -y when confirmed' {
+            $null = Update-ChocolateyPackage -Name 'git' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '-y'
+        }
+
+        It 'Should pass version and source arguments when specified' {
+            $null = Update-ChocolateyPackage -Name 'git' -Version '2.47.0' -Source 'https://community.chocolatey.org/api/v2/' -RunNonElevated -Confirm:$false
+
+            $script:capturedArguments | Should -Contain '--version="2.47.0"'
+            $script:capturedArguments | Should -Contain '-s"https://community.chocolatey.org/api/v2/"'
+        }
+
+        It 'Should not execute when WhatIf is specified' {
+            $null = Update-ChocolateyPackage -Name 'git' -RunNonElevated -WhatIf
+
+            $script:capturedArguments | Should -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the test suite for public and private PowerShell wrapper functions, enhances documentation for command coverage, and raises the code coverage target for CI. The main changes include the addition of comprehensive Pester tests for several key commands, an updated and more detailed command coverage table in the documentation, and a stricter code coverage requirement.

**Test suite improvements:**

- Added new Pester unit tests for the following wrapper functions: `Get-ChocolateyPin`, `Get-ChocolateySource`, `Get-ChocolateySetting`, `Get-ChocolateyFeature`, and `Install-ChocolateyPackage`, ensuring these commands are thoroughly tested for various scenarios and edge cases. [[1]](diffhunk://#diff-de9e154e1369a0d3dfe7a19b6109d3fe11d437c9461ffb0a37c78653807944cfR1-R93) [[2]](diffhunk://#diff-825a04eb1746680d178c2934304b5d6044a3ddda97b535b1800076bf190a8eccR1-R60) [[3]](diffhunk://#diff-ade36c3027b25744096e8e33d0b3bbc95d358e589cfe5e07c78b14a5498cfb17R1-R56) [[4]](diffhunk://#diff-723a564eafce64ba91c8868b301cb6562dd4105357cc1af10951c56c4467e38dR1-R56) [[5]](diffhunk://#diff-2c7be7aba3b45374072ade8c10061a512a524631cafe20453bb827de59256122R1-R90)
- Added a unit test for the private function `Assert-ChocolateyIsElevated`, verifying both elevated and non-elevated execution contexts.

**Documentation updates:**

- Introduced a new **Command coverage** table in `README.md` to track which `choco` CLI commands have PowerShell wrappers. Also updated instructions to require maintaining this table and the "Not yet implemented" list when adding new wrappers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R82) [[2]](diffhunk://#diff-496df50ecbc4c67e85b8f06f770d4ec25be2d65ad469f25e8954c8c150185a8dR43)
- Expanded the documentation for argument completers to reflect additional supported commands.

**Continuous Integration improvements:**

- Increased the code coverage target for Pester tests from 8% to 30% in the CI configuration.